### PR TITLE
Fix typos

### DIFF
--- a/stories/tabs.stories.js
+++ b/stories/tabs.stories.js
@@ -49,8 +49,8 @@ storiesOf('Tabs, Tab', module)
       </Tab>
       <Tab title="Compatibility">
         <p style={{ marginTop: 0, marginBottom: '1.6em' }}>
-          If you have problem with this program and it worked correctly on an
-          earlier version of Windows, select the compatibility m ode that mathes
+          If you have problems with this program and it worked correctly on an
+          earlier version of Windows, select the compatibility mode that matches
           that earlier version.
         </p>
 


### PR DESCRIPTION
I corrected a few typos in the Tabs example.

![](https://user-images.githubusercontent.com/1034878/55231147-0fdcb900-5222-11e9-9579-9f4cf657fa03.png)
