### PR TITLE
docs(modal): fix typo in code const

### DIFF
--- a/stories/modal.stories.js
+++ b/stories/modal.stories.js
@@ -67,7 +67,7 @@ const code = `<Modal
   title="Browse"
   closeModal={() => {}}
   buttons={[
-    { value: 'Ok', onClick: () => {}) },
+    { value: 'Ok', onClick: () => {} },
     { value: 'Cancel', onClick: () => {} },
   ]}
   menu={[


### PR DESCRIPTION
just a small typo when copying the code to use as example.