### PR TITLE
Bugfix: fix radiobutton checked disabled

### DIFF
--- a/components/RadioButton/RadioButton.jsx
+++ b/components/RadioButton/RadioButton.jsx
@@ -50,7 +50,7 @@ const Field = styled.input.attrs({
     background-image: url(${radioUncheckedDisabled});
   }
 
-  &:checked &:disabled + ${Icon} {
+  &:checked:disabled + ${Icon} {
     background-image: url(${radioCheckedDisabled});
   }
 `;

--- a/components/RadioButton/RadioButton.test.jsx
+++ b/components/RadioButton/RadioButton.test.jsx
@@ -13,6 +13,16 @@ describe('<RadioButton />', () => {
       const { container } = render(<RadioButton disabled />);
       expect(container).toMatchSnapshot();
     });
+
+    it('should match snapshot with checked prop', () => {
+      const { container } = render(<RadioButton checked />);
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with checked and disabled prop', () => {
+      const { container } = render(<RadioButton checked disabled />);
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('onChange prop', () => {

--- a/components/RadioButton/__snapshots__/RadioButton.test.jsx.snap
+++ b/components/RadioButton/__snapshots__/RadioButton.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<RadioButton /> Snapshots should match snapshot with disabled prop 1`] = `
-.c4 {
+exports[`<RadioButton /> Snapshots should match snapshot with checked and disabled prop 1`] = `
+.c3 {
   width: 12px;
   height: 12px;
   content: '';
@@ -12,7 +12,7 @@ exports[`<RadioButton /> Snapshots should match snapshot with disabled prop 1`] 
   background-image: url(test-file-stub);
 }
 
-.c6 {
+.c5 {
   padding: 1px;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -23,26 +23,26 @@ exports[`<RadioButton /> Snapshots should match snapshot with disabled prop 1`] 
   left: 18px;
 }
 
-.c2 {
+.c1 {
   margin: 0;
   opacity: 0;
 }
 
-.c2:focus ~ .c5,
-.c2:active + .c5 {
+.c1:focus ~ .c4,
+.c1:active + .c4 {
   border: 1px dotted;
   padding: 0;
 }
 
-.c2:checked + .c3 {
+.c1:checked + .c2 {
   background-image: url(test-file-stub);
 }
 
-.c2:disabled + .c3 {
+.c1:disabled + .c2 {
   background-image: url(test-file-stub);
 }
 
-.c2:checked .c1:disabled + .c3 {
+.c1:checked:disabled + .c2 {
   background-image: url(test-file-stub);
 }
 
@@ -59,22 +59,23 @@ exports[`<RadioButton /> Snapshots should match snapshot with disabled prop 1`] 
     disabled=""
   >
     <input
-      class="c1 c2"
+      checked=""
+      class="c1"
       disabled=""
       type="radio"
     />
     <span
-      class="c3 c4"
+      class="c2 c3"
     />
     <span
-      class="c5 c6"
+      class="c4 c5"
     />
   </label>
 </div>
 `;
 
-exports[`<RadioButton /> Snapshots should match snapshot without props 1`] = `
-.c4 {
+exports[`<RadioButton /> Snapshots should match snapshot with checked prop 1`] = `
+.c3 {
   width: 12px;
   height: 12px;
   content: '';
@@ -85,7 +86,7 @@ exports[`<RadioButton /> Snapshots should match snapshot without props 1`] = `
   background-image: url(test-file-stub);
 }
 
-.c6 {
+.c5 {
   padding: 1px;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -96,26 +97,26 @@ exports[`<RadioButton /> Snapshots should match snapshot without props 1`] = `
   left: 18px;
 }
 
-.c2 {
+.c1 {
   margin: 0;
   opacity: 0;
 }
 
-.c2:focus ~ .c5,
-.c2:active + .c5 {
+.c1:focus ~ .c4,
+.c1:active + .c4 {
   border: 1px dotted;
   padding: 0;
 }
 
-.c2:checked + .c3 {
+.c1:checked + .c2 {
   background-image: url(test-file-stub);
 }
 
-.c2:disabled + .c3 {
+.c1:disabled + .c2 {
   background-image: url(test-file-stub);
 }
 
-.c2:checked .c1:disabled + .c3 {
+.c1:checked:disabled + .c2 {
   background-image: url(test-file-stub);
 }
 
@@ -129,14 +130,157 @@ exports[`<RadioButton /> Snapshots should match snapshot without props 1`] = `
     class="c0"
   >
     <input
-      class="c1 c2"
+      checked=""
+      class="c1"
       type="radio"
     />
     <span
-      class="c3 c4"
+      class="c2 c3"
     />
     <span
-      class="c5 c6"
+      class="c4 c5"
+    />
+  </label>
+</div>
+`;
+
+exports[`<RadioButton /> Snapshots should match snapshot with disabled prop 1`] = `
+.c3 {
+  width: 12px;
+  height: 12px;
+  content: '';
+  display: inline-block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  background-image: url(test-file-stub);
+}
+
+.c5 {
+  padding: 1px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: absolute;
+  top: 0;
+  left: 18px;
+}
+
+.c1 {
+  margin: 0;
+  opacity: 0;
+}
+
+.c1:focus ~ .c4,
+.c1:active + .c4 {
+  border: 1px dotted;
+  padding: 0;
+}
+
+.c1:checked + .c2 {
+  background-image: url(test-file-stub);
+}
+
+.c1:disabled + .c2 {
+  background-image: url(test-file-stub);
+}
+
+.c1:checked:disabled + .c2 {
+  background-image: url(test-file-stub);
+}
+
+.c0 {
+  position: relative;
+  margin-bottom: 10px;
+  color: #868686;
+  text-shadow: 0.5px 0.5px #d2d2d2;
+}
+
+<div>
+  <label
+    class="c0"
+    disabled=""
+  >
+    <input
+      class="c1"
+      disabled=""
+      type="radio"
+    />
+    <span
+      class="c2 c3"
+    />
+    <span
+      class="c4 c5"
+    />
+  </label>
+</div>
+`;
+
+exports[`<RadioButton /> Snapshots should match snapshot without props 1`] = `
+.c3 {
+  width: 12px;
+  height: 12px;
+  content: '';
+  display: inline-block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  background-image: url(test-file-stub);
+}
+
+.c5 {
+  padding: 1px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: absolute;
+  top: 0;
+  left: 18px;
+}
+
+.c1 {
+  margin: 0;
+  opacity: 0;
+}
+
+.c1:focus ~ .c4,
+.c1:active + .c4 {
+  border: 1px dotted;
+  padding: 0;
+}
+
+.c1:checked + .c2 {
+  background-image: url(test-file-stub);
+}
+
+.c1:disabled + .c2 {
+  background-image: url(test-file-stub);
+}
+
+.c1:checked:disabled + .c2 {
+  background-image: url(test-file-stub);
+}
+
+.c0 {
+  position: relative;
+  margin-bottom: 10px;
+}
+
+<div>
+  <label
+    class="c0"
+  >
+    <input
+      class="c1"
+      type="radio"
+    />
+    <span
+      class="c2 c3"
+    />
+    <span
+      class="c4 c5"
     />
   </label>
 </div>


### PR DESCRIPTION
PR to close the #111 issue

According to css rules: pseudo-classes applied together should be chained.  

Using construction similar to: `&:checked &:disabled` caused creation of two separate CSS rules and I can't say what exact state will led them to being applied. 

My proposal is to just compress rule to `&:checked:disabled` so it can work.

Screenshot: 

![Screen Shot 2019-07-22 at 23 35 25](https://user-images.githubusercontent.com/15021175/61663530-7f971800-acd9-11e9-8245-05abd907f717.png)

I've also updated snapshots just-in-case and upgraded test the same way. Unfortunately, found no way to test whether two snapshots match each other (to check if `:checked:disabled` order makes changes).

You can see in `components/RadioButton/__snapshots__/RadioButton.test.jsx.snap` line `262` (of my proposed file), that classes seem to render correctly.