### PR TITLE
Fix icons package.json

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -12,14 +12,9 @@
   "homepage": "https://react95.github.io/React95/",
   "license": "MIT",
   "main": "index.js",
-  "directories": {
-    "src": "src"
-  },
-  "files": [
-    "src"
-  ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "directory": "dist"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove the `directories` and `files` fields from `package.json` and adds `directory: "dist"` inside `publishConfig`.
This way the CI will publish the correct directory.