### PR TITLE
Modal: Add <li> in OptionsBox

### DIFF
--- a/packages/core/components/Alert/__snapshots__/Alert.snap
+++ b/packages/core/components/Alert/__snapshots__/Alert.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Alert /> Snapshots should match snapshot with error type 1`] = `
-.c11 {
+.c12 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
@@ -9,17 +9,17 @@ exports[`<Alert /> Snapshots should match snapshot with error type 1`] = `
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
 }
 
-.c11:disabled {
+.c12:disabled {
   color: #868a8e;
 }
 
-.c11:focus {
+.c12:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c11:active {
+.c12:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
@@ -74,13 +74,24 @@ exports[`<Alert /> Snapshots should match snapshot with error type 1`] = `
   display: flex;
 }
 
-.c5 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: 2px;
+}
+
+.c4:last-child {
+  margin-right: 0;
+}
+
+.c6 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
   font-size: 12px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
-  margin-right: 2px;
   padding: 0;
   width: 17px;
   height: 14px;
@@ -88,37 +99,33 @@ exports[`<Alert /> Snapshots should match snapshot with error type 1`] = `
   font-size: 10px;
 }
 
-.c5:disabled {
+.c6:disabled {
   color: #868a8e;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c5:active {
+.c6:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 0 0 0 1px #868a8e, 0 0 0 1px #000000;
 }
 
-.c5:last-child {
-  margin-right: 0;
-}
-
-.c5:active {
+.c6:active {
   padding: 1px 0 0 1px;
   outline: none;
 }
 
-.c5:focus {
+.c6:focus {
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -1px -1px 0px 1px #868a8e;
 }
 
-.c6 {
+.c7 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -133,7 +140,7 @@ exports[`<Alert /> Snapshots should match snapshot with error type 1`] = `
   padding: 6px;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -148,16 +155,16 @@ exports[`<Alert /> Snapshots should match snapshot with error type 1`] = `
   padding: 0 6px 6px 6px;
 }
 
-.c10 .c4 {
+.c11 .c5 {
   margin-right: 6px;
   min-width: 70px;
 }
 
-.c10 .c4:last-child {
+.c11 .c5:last-child {
   margin-right: 0;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -172,7 +179,7 @@ exports[`<Alert /> Snapshots should match snapshot with error type 1`] = `
   justify-content: center;
 }
 
-.c8 {
+.c9 {
   background-repeat: no-repeat;
   background-size: 70%;
   height: 45px;
@@ -182,7 +189,7 @@ exports[`<Alert /> Snapshots should match snapshot with error type 1`] = `
   background-image: url(test-file-stub);
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -209,40 +216,48 @@ exports[`<Alert /> Snapshots should match snapshot with error type 1`] = `
       <ul
         class="c3"
       >
-        <button
-          class="c4 c5"
+        <li
+          class="c4"
         >
-          ?
-        </button>
-        <button
-          class="c4 c5"
+          <button
+            class="c5 c6"
+          >
+            ?
+          </button>
+        </li>
+        <li
+          class="c4"
         >
-          x
-        </button>
+          <button
+            class="c5 c6"
+          >
+            x
+          </button>
+        </li>
       </ul>
     </div>
     <div
-      class="c6"
+      class="c7"
     >
       <div
-        class="c7"
+        class="c8"
       >
         <div
-          class="c8"
+          class="c9"
           type="error"
         />
         <div
-          class="c9"
+          class="c10"
         >
           Error
         </div>
       </div>
     </div>
     <div
-      class="c10"
+      class="c11"
     >
       <button
-        class="c4 c11"
+        class="c5 c12"
         value="OK"
       >
         OK
@@ -253,7 +268,7 @@ exports[`<Alert /> Snapshots should match snapshot with error type 1`] = `
 `;
 
 exports[`<Alert /> Snapshots should match snapshot with info type 1`] = `
-.c11 {
+.c12 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
@@ -261,17 +276,17 @@ exports[`<Alert /> Snapshots should match snapshot with info type 1`] = `
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
 }
 
-.c11:disabled {
+.c12:disabled {
   color: #868a8e;
 }
 
-.c11:focus {
+.c12:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c11:active {
+.c12:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
@@ -326,13 +341,24 @@ exports[`<Alert /> Snapshots should match snapshot with info type 1`] = `
   display: flex;
 }
 
-.c5 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: 2px;
+}
+
+.c4:last-child {
+  margin-right: 0;
+}
+
+.c6 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
   font-size: 12px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
-  margin-right: 2px;
   padding: 0;
   width: 17px;
   height: 14px;
@@ -340,37 +366,33 @@ exports[`<Alert /> Snapshots should match snapshot with info type 1`] = `
   font-size: 10px;
 }
 
-.c5:disabled {
+.c6:disabled {
   color: #868a8e;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c5:active {
+.c6:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 0 0 0 1px #868a8e, 0 0 0 1px #000000;
 }
 
-.c5:last-child {
-  margin-right: 0;
-}
-
-.c5:active {
+.c6:active {
   padding: 1px 0 0 1px;
   outline: none;
 }
 
-.c5:focus {
+.c6:focus {
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -1px -1px 0px 1px #868a8e;
 }
 
-.c6 {
+.c7 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -385,7 +407,7 @@ exports[`<Alert /> Snapshots should match snapshot with info type 1`] = `
   padding: 6px;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -400,16 +422,16 @@ exports[`<Alert /> Snapshots should match snapshot with info type 1`] = `
   padding: 0 6px 6px 6px;
 }
 
-.c10 .c4 {
+.c11 .c5 {
   margin-right: 6px;
   min-width: 70px;
 }
 
-.c10 .c4:last-child {
+.c11 .c5:last-child {
   margin-right: 0;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -424,7 +446,7 @@ exports[`<Alert /> Snapshots should match snapshot with info type 1`] = `
   justify-content: center;
 }
 
-.c8 {
+.c9 {
   background-repeat: no-repeat;
   background-size: 70%;
   height: 45px;
@@ -434,7 +456,7 @@ exports[`<Alert /> Snapshots should match snapshot with info type 1`] = `
   background-image: url(test-file-stub);
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -461,40 +483,48 @@ exports[`<Alert /> Snapshots should match snapshot with info type 1`] = `
       <ul
         class="c3"
       >
-        <button
-          class="c4 c5"
+        <li
+          class="c4"
         >
-          ?
-        </button>
-        <button
-          class="c4 c5"
+          <button
+            class="c5 c6"
+          >
+            ?
+          </button>
+        </li>
+        <li
+          class="c4"
         >
-          x
-        </button>
+          <button
+            class="c5 c6"
+          >
+            x
+          </button>
+        </li>
       </ul>
     </div>
     <div
-      class="c6"
+      class="c7"
     >
       <div
-        class="c7"
+        class="c8"
       >
         <div
-          class="c8"
+          class="c9"
           type="info"
         />
         <div
-          class="c9"
+          class="c10"
         >
           Info
         </div>
       </div>
     </div>
     <div
-      class="c10"
+      class="c11"
     >
       <button
-        class="c4 c11"
+        class="c5 c12"
         value="OK"
       >
         OK
@@ -505,7 +535,7 @@ exports[`<Alert /> Snapshots should match snapshot with info type 1`] = `
 `;
 
 exports[`<Alert /> Snapshots should match snapshot with question type 1`] = `
-.c11 {
+.c12 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
@@ -513,17 +543,17 @@ exports[`<Alert /> Snapshots should match snapshot with question type 1`] = `
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
 }
 
-.c11:disabled {
+.c12:disabled {
   color: #868a8e;
 }
 
-.c11:focus {
+.c12:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c11:active {
+.c12:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
@@ -578,13 +608,24 @@ exports[`<Alert /> Snapshots should match snapshot with question type 1`] = `
   display: flex;
 }
 
-.c5 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: 2px;
+}
+
+.c4:last-child {
+  margin-right: 0;
+}
+
+.c6 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
   font-size: 12px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
-  margin-right: 2px;
   padding: 0;
   width: 17px;
   height: 14px;
@@ -592,37 +633,33 @@ exports[`<Alert /> Snapshots should match snapshot with question type 1`] = `
   font-size: 10px;
 }
 
-.c5:disabled {
+.c6:disabled {
   color: #868a8e;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c5:active {
+.c6:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 0 0 0 1px #868a8e, 0 0 0 1px #000000;
 }
 
-.c5:last-child {
-  margin-right: 0;
-}
-
-.c5:active {
+.c6:active {
   padding: 1px 0 0 1px;
   outline: none;
 }
 
-.c5:focus {
+.c6:focus {
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -1px -1px 0px 1px #868a8e;
 }
 
-.c6 {
+.c7 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -637,7 +674,7 @@ exports[`<Alert /> Snapshots should match snapshot with question type 1`] = `
   padding: 6px;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -652,16 +689,16 @@ exports[`<Alert /> Snapshots should match snapshot with question type 1`] = `
   padding: 0 6px 6px 6px;
 }
 
-.c10 .c4 {
+.c11 .c5 {
   margin-right: 6px;
   min-width: 70px;
 }
 
-.c10 .c4:last-child {
+.c11 .c5:last-child {
   margin-right: 0;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -676,7 +713,7 @@ exports[`<Alert /> Snapshots should match snapshot with question type 1`] = `
   justify-content: center;
 }
 
-.c8 {
+.c9 {
   background-repeat: no-repeat;
   background-size: 70%;
   height: 45px;
@@ -686,7 +723,7 @@ exports[`<Alert /> Snapshots should match snapshot with question type 1`] = `
   background-image: url(test-file-stub);
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -713,40 +750,48 @@ exports[`<Alert /> Snapshots should match snapshot with question type 1`] = `
       <ul
         class="c3"
       >
-        <button
-          class="c4 c5"
+        <li
+          class="c4"
         >
-          ?
-        </button>
-        <button
-          class="c4 c5"
+          <button
+            class="c5 c6"
+          >
+            ?
+          </button>
+        </li>
+        <li
+          class="c4"
         >
-          x
-        </button>
+          <button
+            class="c5 c6"
+          >
+            x
+          </button>
+        </li>
       </ul>
     </div>
     <div
-      class="c6"
+      class="c7"
     >
       <div
-        class="c7"
+        class="c8"
       >
         <div
-          class="c8"
+          class="c9"
           type="question"
         />
         <div
-          class="c9"
+          class="c10"
         >
           question
         </div>
       </div>
     </div>
     <div
-      class="c10"
+      class="c11"
     >
       <button
-        class="c4 c11"
+        class="c5 c12"
         value="OK"
       >
         OK
@@ -757,7 +802,7 @@ exports[`<Alert /> Snapshots should match snapshot with question type 1`] = `
 `;
 
 exports[`<Alert /> Snapshots should match snapshot with warning type 1`] = `
-.c11 {
+.c12 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
@@ -765,17 +810,17 @@ exports[`<Alert /> Snapshots should match snapshot with warning type 1`] = `
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
 }
 
-.c11:disabled {
+.c12:disabled {
   color: #868a8e;
 }
 
-.c11:focus {
+.c12:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c11:active {
+.c12:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
@@ -830,13 +875,24 @@ exports[`<Alert /> Snapshots should match snapshot with warning type 1`] = `
   display: flex;
 }
 
-.c5 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: 2px;
+}
+
+.c4:last-child {
+  margin-right: 0;
+}
+
+.c6 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
   font-size: 12px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
-  margin-right: 2px;
   padding: 0;
   width: 17px;
   height: 14px;
@@ -844,37 +900,33 @@ exports[`<Alert /> Snapshots should match snapshot with warning type 1`] = `
   font-size: 10px;
 }
 
-.c5:disabled {
+.c6:disabled {
   color: #868a8e;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c5:active {
+.c6:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 0 0 0 1px #868a8e, 0 0 0 1px #000000;
 }
 
-.c5:last-child {
-  margin-right: 0;
-}
-
-.c5:active {
+.c6:active {
   padding: 1px 0 0 1px;
   outline: none;
 }
 
-.c5:focus {
+.c6:focus {
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -1px -1px 0px 1px #868a8e;
 }
 
-.c6 {
+.c7 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -889,7 +941,7 @@ exports[`<Alert /> Snapshots should match snapshot with warning type 1`] = `
   padding: 6px;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -904,16 +956,16 @@ exports[`<Alert /> Snapshots should match snapshot with warning type 1`] = `
   padding: 0 6px 6px 6px;
 }
 
-.c10 .c4 {
+.c11 .c5 {
   margin-right: 6px;
   min-width: 70px;
 }
 
-.c10 .c4:last-child {
+.c11 .c5:last-child {
   margin-right: 0;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -928,7 +980,7 @@ exports[`<Alert /> Snapshots should match snapshot with warning type 1`] = `
   justify-content: center;
 }
 
-.c8 {
+.c9 {
   background-repeat: no-repeat;
   background-size: 70%;
   height: 45px;
@@ -938,7 +990,7 @@ exports[`<Alert /> Snapshots should match snapshot with warning type 1`] = `
   background-image: url(test-file-stub);
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -965,40 +1017,48 @@ exports[`<Alert /> Snapshots should match snapshot with warning type 1`] = `
       <ul
         class="c3"
       >
-        <button
-          class="c4 c5"
+        <li
+          class="c4"
         >
-          ?
-        </button>
-        <button
-          class="c4 c5"
+          <button
+            class="c5 c6"
+          >
+            ?
+          </button>
+        </li>
+        <li
+          class="c4"
         >
-          x
-        </button>
+          <button
+            class="c5 c6"
+          >
+            x
+          </button>
+        </li>
       </ul>
     </div>
     <div
-      class="c6"
+      class="c7"
     >
       <div
-        class="c7"
+        class="c8"
       >
         <div
-          class="c8"
+          class="c9"
           type="warning"
         />
         <div
-          class="c9"
+          class="c10"
         >
           Warning
         </div>
       </div>
     </div>
     <div
-      class="c10"
+      class="c11"
     >
       <button
-        class="c4 c11"
+        class="c5 c12"
         value="OK"
       >
         OK

--- a/packages/core/components/Modal/Modal.test.tsx
+++ b/packages/core/components/Modal/Modal.test.tsx
@@ -189,7 +189,7 @@ describe('<Modal />', () => {
 
   describe('Menus', () => {
     it('should display menu name correctly', async () => {
-      const { container } = await waitRender(
+      const { getByTestId } = await waitRender(
         <Modal
           title="file.bat"
           closeModal={() => {}}
@@ -207,8 +207,7 @@ describe('<Modal />', () => {
           Hello
         </Modal>,
       );
-
-      expect(container.querySelector('li')?.textContent).toBe('Menu Text');
+      expect(getByTestId('menu-item')?.textContent).toBe('Menu Text');
     });
 
     it('should display menu list correctly', async () => {

--- a/packages/core/components/Modal/Modal.test.tsx
+++ b/packages/core/components/Modal/Modal.test.tsx
@@ -189,7 +189,7 @@ describe('<Modal />', () => {
 
   describe('Menus', () => {
     it('should display menu name correctly', async () => {
-      const { getByTestId } = await waitRender(
+      const { getByText } = await waitRender(
         <Modal
           title="file.bat"
           closeModal={() => {}}
@@ -207,7 +207,7 @@ describe('<Modal />', () => {
           Hello
         </Modal>,
       );
-      expect(getByTestId('menu-item')?.textContent).toBe('Menu Text');
+      expect(getByText('Menu Text')).toBeInTheDocument();
     });
 
     it('should display menu list correctly', async () => {

--- a/packages/core/components/Modal/Modal.tsx
+++ b/packages/core/components/Modal/Modal.tsx
@@ -67,8 +67,16 @@ const OptionsBox = styled.ul`
   display: flex;
 `;
 
-const Option = styled(Btn)`
+const OptionItem = styled.li`
+  display: flex;
   margin-right: 2;
+
+  &:last-child {
+    margin-right: 0;
+  }
+`;
+
+const Option = styled(Btn)`
   padding: 0;
 
   width: 17px;
@@ -76,10 +84,6 @@ const Option = styled(Btn)`
   min-width: 0;
 
   font-size: 10;
-
-  &:last-child {
-    margin-right: 0;
-  }
 
   &:active {
     padding: 1 0 0 1;
@@ -247,8 +251,12 @@ const ModalRenderer = (
           {icon && <Icon name={icon} {...iconStyle} />}
           <Title>{title}</Title>
           <OptionsBox>
-            <Option>?</Option>
-            <Option onClick={closeModal}>x</Option>
+            <OptionItem>
+              <Option>?</Option>
+            </OptionItem>
+            <OptionItem>
+              <Option onClick={closeModal}>x</Option>
+            </OptionItem>
           </OptionsBox>
         </TitleBar>
 
@@ -261,6 +269,7 @@ const ModalRenderer = (
                   key={name}
                   onMouseDown={() => setMenuOpened(name)}
                   active={active}
+                  data-testid="menu-item"
                 >
                   {name}
                   {active && list}

--- a/packages/core/components/Modal/Modal.tsx
+++ b/packages/core/components/Modal/Modal.tsx
@@ -269,7 +269,6 @@ const ModalRenderer = (
                   key={name}
                   onMouseDown={() => setMenuOpened(name)}
                   active={active}
-                  data-testid="menu-item"
                 >
                   {name}
                   {active && list}

--- a/packages/core/components/Modal/__snapshots__/Modal.snap
+++ b/packages/core/components/Modal/__snapshots__/Modal.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Modal /> Snapshots should match snapshot 1`] = `
-.c11 {
+.c12 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
@@ -9,17 +9,17 @@ exports[`<Modal /> Snapshots should match snapshot 1`] = `
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
 }
 
-.c11:disabled {
+.c12:disabled {
   color: #868a8e;
 }
 
-.c11:focus {
+.c12:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c11:active {
+.c12:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
@@ -83,13 +83,24 @@ exports[`<Modal /> Snapshots should match snapshot 1`] = `
   display: flex;
 }
 
-.c6 {
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: 2px;
+}
+
+.c5:last-child {
+  margin-right: 0;
+}
+
+.c7 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
   font-size: 12px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
-  margin-right: 2px;
   padding: 0;
   width: 17px;
   height: 14px;
@@ -97,37 +108,33 @@ exports[`<Modal /> Snapshots should match snapshot 1`] = `
   font-size: 10px;
 }
 
-.c6:disabled {
+.c7:disabled {
   color: #868a8e;
 }
 
-.c6:focus {
+.c7:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c6:active {
+.c7:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 0 0 0 1px #868a8e, 0 0 0 1px #000000;
 }
 
-.c6:last-child {
-  margin-right: 0;
-}
-
-.c6:active {
+.c7:active {
   padding: 1px 0 0 1px;
   outline: none;
 }
 
-.c6:focus {
+.c7:focus {
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -1px -1px 0px 1px #868a8e;
 }
 
-.c9 {
+.c10 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -142,7 +149,7 @@ exports[`<Modal /> Snapshots should match snapshot 1`] = `
   padding: 6px;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -157,16 +164,16 @@ exports[`<Modal /> Snapshots should match snapshot 1`] = `
   padding: 0 6px 6px 6px;
 }
 
-.c10 .c5 {
+.c11 .c6 {
   margin-right: 6px;
   min-width: 70px;
 }
 
-.c10 .c5:last-child {
+.c11 .c6:last-child {
   margin-right: 0;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -184,7 +191,7 @@ exports[`<Modal /> Snapshots should match snapshot 1`] = `
   box-shadow: 0 1px 0 0 #e6e6e6;
 }
 
-.c8 {
+.c9 {
   position: relative;
   padding-left: 6px;
   padding-right: 6px;
@@ -194,7 +201,7 @@ exports[`<Modal /> Snapshots should match snapshot 1`] = `
   user-select: none;
 }
 
-.c8 ul {
+.c9 ul {
   position: absolute;
   left: 0;
   color: #000000;
@@ -223,48 +230,58 @@ exports[`<Modal /> Snapshots should match snapshot 1`] = `
       <ul
         class="c4"
       >
-        <button
-          class="c5 c6"
+        <li
+          class="c5"
         >
-          ?
-        </button>
-        <button
-          class="c5 c6"
+          <button
+            class="c6 c7"
+          >
+            ?
+          </button>
+        </li>
+        <li
+          class="c5"
         >
-          x
-        </button>
+          <button
+            class="c6 c7"
+          >
+            x
+          </button>
+        </li>
       </ul>
     </div>
     <ul
-      class="c7"
+      class="c8"
     >
       <li
-        class="c8"
+        class="c9"
+        data-testid="menu-item"
       >
         File
       </li>
       <li
-        class="c8"
+        class="c9"
+        data-testid="menu-item"
       >
         Edit
       </li>
     </ul>
     <div
-      class="c9"
+      class="c10"
     >
       Hello
     </div>
     <div
-      class="c10"
+      class="c11"
     >
       <button
-        class="c5 c11"
+        class="c6 c12"
         value="Ok"
       >
         Ok
       </button>
       <button
-        class="c5 c11"
+        class="c6 c12"
         value="Cancel"
       >
         Cancel
@@ -275,7 +292,7 @@ exports[`<Modal /> Snapshots should match snapshot 1`] = `
 `;
 
 exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equals center 1`] = `
-.c9 {
+.c10 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
@@ -283,17 +300,17 @@ exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equ
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
 }
 
-.c9:disabled {
+.c10:disabled {
   color: #868a8e;
 }
 
-.c9:focus {
+.c10:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c9:active {
+.c10:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
@@ -357,13 +374,24 @@ exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equ
   display: flex;
 }
 
-.c6 {
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: 2px;
+}
+
+.c5:last-child {
+  margin-right: 0;
+}
+
+.c7 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
   font-size: 12px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
-  margin-right: 2px;
   padding: 0;
   width: 17px;
   height: 14px;
@@ -371,37 +399,33 @@ exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equ
   font-size: 10px;
 }
 
-.c6:disabled {
+.c7:disabled {
   color: #868a8e;
 }
 
-.c6:focus {
+.c7:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c6:active {
+.c7:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 0 0 0 1px #868a8e, 0 0 0 1px #000000;
 }
 
-.c6:last-child {
-  margin-right: 0;
-}
-
-.c6:active {
+.c7:active {
   padding: 1px 0 0 1px;
   outline: none;
 }
 
-.c6:focus {
+.c7:focus {
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -1px -1px 0px 1px #868a8e;
 }
 
-.c7 {
+.c8 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -416,7 +440,7 @@ exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equ
   padding: 6px;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -431,12 +455,12 @@ exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equ
   padding: 0 6px 6px 6px;
 }
 
-.c8 .c5 {
+.c9 .c6 {
   margin-right: 6px;
   min-width: 70px;
 }
 
-.c8 .c5:last-child {
+.c9 .c6:last-child {
   margin-right: 0;
 }
 
@@ -463,34 +487,42 @@ exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equ
       <ul
         class="c4"
       >
-        <button
-          class="c5 c6"
+        <li
+          class="c5"
         >
-          ?
-        </button>
-        <button
-          class="c5 c6"
+          <button
+            class="c6 c7"
+          >
+            ?
+          </button>
+        </li>
+        <li
+          class="c5"
         >
-          x
-        </button>
+          <button
+            class="c6 c7"
+          >
+            x
+          </button>
+        </li>
       </ul>
-    </div>
-    <div
-      class="c7"
-    >
-      Hello
     </div>
     <div
       class="c8"
     >
+      Hello
+    </div>
+    <div
+      class="c9"
+    >
       <button
-        class="c5 c9"
+        class="c6 c10"
         value="Ok"
       >
         Ok
       </button>
       <button
-        class="c5 c9"
+        class="c6 c10"
         value="Cancel"
       >
         Cancel
@@ -501,7 +533,7 @@ exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equ
 `;
 
 exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equals flex-start 1`] = `
-.c9 {
+.c10 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
@@ -509,17 +541,17 @@ exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equ
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
 }
 
-.c9:disabled {
+.c10:disabled {
   color: #868a8e;
 }
 
-.c9:focus {
+.c10:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c9:active {
+.c10:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
@@ -583,13 +615,24 @@ exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equ
   display: flex;
 }
 
-.c6 {
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: 2px;
+}
+
+.c5:last-child {
+  margin-right: 0;
+}
+
+.c7 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
   font-size: 12px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
-  margin-right: 2px;
   padding: 0;
   width: 17px;
   height: 14px;
@@ -597,37 +640,33 @@ exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equ
   font-size: 10px;
 }
 
-.c6:disabled {
+.c7:disabled {
   color: #868a8e;
 }
 
-.c6:focus {
+.c7:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c6:active {
+.c7:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 0 0 0 1px #868a8e, 0 0 0 1px #000000;
 }
 
-.c6:last-child {
-  margin-right: 0;
-}
-
-.c6:active {
+.c7:active {
   padding: 1px 0 0 1px;
   outline: none;
 }
 
-.c6:focus {
+.c7:focus {
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -1px -1px 0px 1px #868a8e;
 }
 
-.c7 {
+.c8 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -642,7 +681,7 @@ exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equ
   padding: 6px;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -657,12 +696,12 @@ exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equ
   padding: 0 6px 6px 6px;
 }
 
-.c8 .c5 {
+.c9 .c6 {
   margin-right: 6px;
   min-width: 70px;
 }
 
-.c8 .c5:last-child {
+.c9 .c6:last-child {
   margin-right: 0;
 }
 
@@ -689,34 +728,42 @@ exports[`<Modal /> Snapshots should match snapshot with buttonsAligment prop equ
       <ul
         class="c4"
       >
-        <button
-          class="c5 c6"
+        <li
+          class="c5"
         >
-          ?
-        </button>
-        <button
-          class="c5 c6"
+          <button
+            class="c6 c7"
+          >
+            ?
+          </button>
+        </li>
+        <li
+          class="c5"
         >
-          x
-        </button>
+          <button
+            class="c6 c7"
+          >
+            x
+          </button>
+        </li>
       </ul>
-    </div>
-    <div
-      class="c7"
-    >
-      Hello
     </div>
     <div
       class="c8"
     >
+      Hello
+    </div>
+    <div
+      class="c9"
+    >
       <button
-        class="c5 c9"
+        class="c6 c10"
         value="Ok"
       >
         Ok
       </button>
       <button
-        class="c5 c9"
+        class="c6 c10"
         value="Cancel"
       >
         Cancel
@@ -784,12 +831,23 @@ exports[`<Modal /> Snapshots should match snapshot with different activeWindow 1
 }
 
 .c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: 2px;
+}
+
+.c5:last-child {
+  margin-right: 0;
+}
+
+.c6 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
   font-size: 12px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
-  margin-right: 2px;
   padding: 0;
   width: 17px;
   height: 14px;
@@ -797,37 +855,33 @@ exports[`<Modal /> Snapshots should match snapshot with different activeWindow 1
   font-size: 10px;
 }
 
-.c5:disabled {
+.c6:disabled {
   color: #868a8e;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c5:active {
+.c6:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 0 0 0 1px #868a8e, 0 0 0 1px #000000;
 }
 
-.c5:last-child {
-  margin-right: 0;
-}
-
-.c5:active {
+.c6:active {
   padding: 1px 0 0 1px;
   outline: none;
 }
 
-.c5:focus {
+.c6:focus {
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -1px -1px 0px 1px #868a8e;
 }
 
-.c6 {
+.c7 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -867,20 +921,28 @@ exports[`<Modal /> Snapshots should match snapshot with different activeWindow 1
       <ul
         class="c4"
       >
-        <button
-          class="sc-pscky c5"
+        <li
+          class="c5"
         >
-          ?
-        </button>
-        <button
-          class="sc-pscky c5"
+          <button
+            class="sc-pscky c6"
+          >
+            ?
+          </button>
+        </li>
+        <li
+          class="c5"
         >
-          x
-        </button>
+          <button
+            class="sc-pscky c6"
+          >
+            x
+          </button>
+        </li>
       </ul>
     </div>
     <div
-      class="c6"
+      class="c7"
     >
       Hello
     </div>
@@ -947,12 +1009,23 @@ exports[`<Modal /> Snapshots should match snapshot with width and height props 1
 }
 
 .c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: 2px;
+}
+
+.c5:last-child {
+  margin-right: 0;
+}
+
+.c6 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
   font-size: 12px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
-  margin-right: 2px;
   padding: 0;
   width: 17px;
   height: 14px;
@@ -960,37 +1033,33 @@ exports[`<Modal /> Snapshots should match snapshot with width and height props 1
   font-size: 10px;
 }
 
-.c5:disabled {
+.c6:disabled {
   color: #868a8e;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c5:active {
+.c6:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 0 0 0 1px #868a8e, 0 0 0 1px #000000;
 }
 
-.c5:last-child {
-  margin-right: 0;
-}
-
-.c5:active {
+.c6:active {
   padding: 1px 0 0 1px;
   outline: none;
 }
 
-.c5:focus {
+.c6:focus {
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -1px -1px 0px 1px #868a8e;
 }
 
-.c6 {
+.c7 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -1030,20 +1099,28 @@ exports[`<Modal /> Snapshots should match snapshot with width and height props 1
       <ul
         class="c4"
       >
-        <button
-          class="sc-pscky c5"
+        <li
+          class="c5"
         >
-          ?
-        </button>
-        <button
-          class="sc-pscky c5"
+          <button
+            class="sc-pscky c6"
+          >
+            ?
+          </button>
+        </li>
+        <li
+          class="c5"
         >
-          x
-        </button>
+          <button
+            class="sc-pscky c6"
+          >
+            x
+          </button>
+        </li>
       </ul>
     </div>
     <div
-      class="c6"
+      class="c7"
     >
       Hello
     </div>

--- a/packages/core/components/Modal/__snapshots__/Modal.snap
+++ b/packages/core/components/Modal/__snapshots__/Modal.snap
@@ -255,13 +255,11 @@ exports[`<Modal /> Snapshots should match snapshot 1`] = `
     >
       <li
         class="c9"
-        data-testid="menu-item"
       >
         File
       </li>
       <li
         class="c9"
-        data-testid="menu-item"
       >
         Edit
       </li>

--- a/packages/core/components/Tabs/__snapshots__/Tabs.snap
+++ b/packages/core/components/Tabs/__snapshots__/Tabs.snap
@@ -54,7 +54,7 @@ exports[`<Tabs /> Snapshot should match snapshot 1`] = `
 
 <div>
   <ol
-    class="sc-qXhiz c0"
+    class="sc-pzYib c0"
     height="auto"
     width="auto"
   >
@@ -65,7 +65,7 @@ exports[`<Tabs /> Snapshot should match snapshot 1`] = `
     </li>
   </ol>
   <div
-    class="sc-qXhiz c2"
+    class="sc-pzYib c2"
     height="auto"
     width="auto"
   >

--- a/packages/core/components/TaskBar/__snapshots__/TaskBar.snap
+++ b/packages/core/components/TaskBar/__snapshots__/TaskBar.snap
@@ -76,7 +76,7 @@ exports[`<TaskBar /> Snapshots <WindowButton /> should match snapshot 1`] = `
 
 <div>
   <button
-    class="sc-pItiW c0"
+    class="sc-pQSRh c0"
     height="auto"
     width="auto"
   >
@@ -157,7 +157,7 @@ exports[`<TaskBar /> Snapshots <WindowButton /> should match snapshot with activ
 
 <div>
   <button
-    class="sc-pItiW c0"
+    class="sc-pQSRh c0"
     height="auto"
     width="auto"
   >
@@ -170,7 +170,7 @@ exports[`<TaskBar /> Snapshots <WindowButton /> should match snapshot with activ
     
   </button>
   <button
-    class="sc-pItiW c2"
+    class="sc-pQSRh c2"
     height="auto"
     width="auto"
   >
@@ -222,7 +222,7 @@ exports[`<TaskBar /> Snapshots <WindowButton /> should match snapshot with icon 
 
 <div>
   <button
-    class="sc-pItiW c0"
+    class="sc-pQSRh c0"
     height="auto"
     width="auto"
   >
@@ -274,7 +274,7 @@ exports[`<TaskBar /> Snapshots <WindowButton /> should match snapshot with small
 
 <div>
   <button
-    class="sc-pItiW c0"
+    class="sc-pQSRh c0"
     height="auto"
     width="auto"
   >
@@ -574,7 +574,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with list prop 1`] = `
 exports[`<TaskBar /> Snapshots should match snapshot with list prop 2`] = `
 <div>
   <div
-    class="sc-pItiW gojuKw"
+    class="sc-pQSRh jHQQlH"
     display="flex"
     height="28"
     width="100%"
@@ -685,7 +685,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with list prop 2`] = `
       </ul>
     </div>
     <button
-      class="sc-pItiW sc-pcJja bIJQWW"
+      class="sc-pQSRh sc-pliRl fbgwoX"
       height="auto"
       width="auto"
     >
@@ -699,19 +699,19 @@ exports[`<TaskBar /> Snapshots should match snapshot with list prop 2`] = `
       Start
     </button>
     <div
-      class="sc-pItiW dcSYlO"
+      class="sc-pQSRh PBLSF"
       display="flex"
       height="auto"
       width="100%"
     />
     <div
-      class="sc-pItiW kRyWDA"
+      class="sc-pQSRh eHiMqf"
       height="auto"
       style="display: flex; justify-content: center; align-items: center;"
       width="auto"
     >
       <div
-        class="sc-pZnSc kYvPuw sc-oUoif Iwwvw"
+        class="sc-oUoif iaFRZS sc-pcJja VfkaY"
       >
         
       </div>
@@ -730,7 +730,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with one Modal 1`] = `
   height: 13px;
 }
 
-.c9 {
+.c10 {
   display: block;
   background-repeat: no-repeat;
   background-position: center;
@@ -788,12 +788,23 @@ exports[`<TaskBar /> Snapshots should match snapshot with one Modal 1`] = `
 }
 
 .c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: 2px;
+}
+
+.c5:last-child {
+  margin-right: 0;
+}
+
+.c6 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
   font-size: 12px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
-  margin-right: 2px;
   padding: 0;
   width: 17px;
   height: 14px;
@@ -801,37 +812,33 @@ exports[`<TaskBar /> Snapshots should match snapshot with one Modal 1`] = `
   font-size: 10px;
 }
 
-.c5:disabled {
+.c6:disabled {
   color: #868a8e;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c5:active {
+.c6:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 0 0 0 1px #868a8e, 0 0 0 1px #000000;
 }
 
-.c5:last-child {
-  margin-right: 0;
-}
-
-.c5:active {
+.c6:active {
   padding: 1px 0 0 1px;
   outline: none;
 }
 
-.c5:focus {
+.c6:focus {
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -1px -1px 0px 1px #868a8e;
 }
 
-.c6 {
+.c7 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -846,7 +853,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with one Modal 1`] = `
   padding: 6px;
 }
 
-.c7 {
+.c8 {
   background-color: #c3c7cb;
   display: -webkit-box;
   display: -webkit-flex;
@@ -871,7 +878,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with one Modal 1`] = `
   padding: 2px;
 }
 
-.c10 {
+.c11 {
   background-color: #c3c7cb;
   display: -webkit-box;
   display: -webkit-flex;
@@ -888,7 +895,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with one Modal 1`] = `
   margin-left: 2px;
 }
 
-.c13 {
+.c14 {
   background-color: transparent;
   width: auto;
   height: auto;
@@ -899,18 +906,18 @@ exports[`<TaskBar /> Snapshots should match snapshot with one Modal 1`] = `
   padding-bottom: 2px;
 }
 
-.c14 {
+.c15 {
   display: inline-block;
   position: relative;
   cursor: default;
   white-space: nowrap;
 }
 
-.c15 div:first-child {
+.c16 div:first-child {
   right: 0;
 }
 
-.c8 {
+.c9 {
   background-color: #c3c7cb;
   width: auto;
   height: auto;
@@ -934,7 +941,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with one Modal 1`] = `
   outline: none;
 }
 
-.c11 {
+.c12 {
   background-color: #e6e6e6;
   width: auto;
   height: auto;
@@ -959,7 +966,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with one Modal 1`] = `
   width: 100%;
 }
 
-.c12 {
+.c13 {
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 1;
@@ -989,35 +996,43 @@ exports[`<TaskBar /> Snapshots should match snapshot with one Modal 1`] = `
       <ul
         class="c4"
       >
-        <button
-          class="sc-pscky c5"
+        <li
+          class="c5"
         >
-          ?
-        </button>
-        <button
-          class="sc-pscky c5"
+          <button
+            class="sc-pscky c6"
+          >
+            ?
+          </button>
+        </li>
+        <li
+          class="c5"
         >
-          x
-        </button>
+          <button
+            class="sc-pscky c6"
+          >
+            x
+          </button>
+        </li>
       </ul>
     </div>
     <div
-      class="c6"
+      class="c7"
     />
   </div>
   <div
-    class="c7"
+    class="c8"
     display="flex"
     height="28"
     width="100%"
   >
     <button
-      class="c8"
+      class="c9"
       height="auto"
       width="auto"
     >
       <i
-        class="c9"
+        class="c10"
         data-icon-name="logo"
         height="20"
         style="margin-right: 4px; background-image: url(buffer-32-4-1);"
@@ -1026,38 +1041,38 @@ exports[`<TaskBar /> Snapshots should match snapshot with one Modal 1`] = `
       Start
     </button>
     <div
-      class="c10"
+      class="c11"
       display="flex"
       height="auto"
       width="100%"
     >
       <button
-        class="c11"
+        class="c12"
         height="auto"
         width="auto"
       >
         <i
-          class="c9"
+          class="c10"
           data-icon-name="bat"
           height="20"
           style="margin-right: 4px; background-image: url(buffer-32-4-1);"
           width="20"
         />
         <span
-          class="c12"
+          class="c13"
         >
           file.bat
         </span>
       </button>
     </div>
     <div
-      class="c13"
+      class="c14"
       height="auto"
       style="display: flex; justify-content: center; align-items: center;"
       width="auto"
     >
       <div
-        class="c14 c15"
+        class="c15 c16"
       >
         
       </div>
@@ -1076,7 +1091,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
   height: 13px;
 }
 
-.c11 {
+.c12 {
   display: block;
   background-repeat: no-repeat;
   background-position: center;
@@ -1102,7 +1117,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
   height: auto;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1132,7 +1147,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
   background-color: #868a8e;
 }
 
-.c8 {
+.c9 {
   height: 18px;
   margin-bottom: 2px;
   color: #ffffff;
@@ -1163,12 +1178,23 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
 }
 
 .c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: 2px;
+}
+
+.c5:last-child {
+  margin-right: 0;
+}
+
+.c6 {
   background-color: #c3c7cb;
   padding: 7px 20px 5px;
   border: none;
   font-size: 12px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset 0 0 0 1px #868a8e,1px 1px 0 0px #000000;
-  margin-right: 2px;
   padding: 0;
   width: 17px;
   height: 14px;
@@ -1176,37 +1202,33 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
   font-size: 10px;
 }
 
-.c5:disabled {
+.c6:disabled {
   color: #868a8e;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -0.5px -0.5px 0px 1px #868a8e, 1px 1px 0 1px #000000;
 }
 
-.c5:active {
+.c6:active {
   padding: 8px 20px 4px;
   outline: 1px dotted #000000;
   outline-offset: -5px;
   box-shadow: inset 0 0 0 1px #868a8e, 0 0 0 1px #000000;
 }
 
-.c5:last-child {
-  margin-right: 0;
-}
-
-.c5:active {
+.c6:active {
   padding: 1px 0 0 1px;
   outline: none;
 }
 
-.c5:focus {
+.c6:focus {
   box-shadow: inset 1px 1px 0px 1px #ffffff, inset -1px -1px 0px 1px #868a8e;
 }
 
-.c6 {
+.c7 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -1221,7 +1243,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
   padding: 6px;
 }
 
-.c9 {
+.c10 {
   background-color: #c3c7cb;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1246,7 +1268,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
   padding: 2px;
 }
 
-.c12 {
+.c13 {
   background-color: #c3c7cb;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1263,7 +1285,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
   margin-left: 2px;
 }
 
-.c16 {
+.c17 {
   background-color: transparent;
   width: auto;
   height: auto;
@@ -1274,18 +1296,18 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
   padding-bottom: 2px;
 }
 
-.c17 {
+.c18 {
   display: inline-block;
   position: relative;
   cursor: default;
   white-space: nowrap;
 }
 
-.c18 div:first-child {
+.c19 div:first-child {
   right: 0;
 }
 
-.c10 {
+.c11 {
   background-color: #c3c7cb;
   width: auto;
   height: auto;
@@ -1309,7 +1331,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
   outline: none;
 }
 
-.c13 {
+.c14 {
   background-color: #c3c7cb;
   width: auto;
   height: auto;
@@ -1334,7 +1356,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
   width: 100%;
 }
 
-.c15 {
+.c16 {
   background-color: #e6e6e6;
   width: auto;
   height: auto;
@@ -1359,7 +1381,7 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
   width: 100%;
 }
 
-.c14 {
+.c15 {
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 1;
@@ -1389,28 +1411,36 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
       <ul
         class="c4"
       >
-        <button
-          class="sc-pscky c5"
+        <li
+          class="c5"
         >
-          ?
-        </button>
-        <button
-          class="sc-pscky c5"
+          <button
+            class="sc-pscky c6"
+          >
+            ?
+          </button>
+        </li>
+        <li
+          class="c5"
         >
-          x
-        </button>
+          <button
+            class="sc-pscky c6"
+          >
+            x
+          </button>
+        </li>
       </ul>
     </div>
     <div
-      class="c6"
+      class="c7"
     />
   </div>
   <div
-    class="c7 react-draggable"
+    class="c8 react-draggable"
     style="transform: translate(0px,0px);"
   >
     <div
-      class="c8 draggable"
+      class="c9 draggable"
     >
       <i
         class="c2"
@@ -1427,35 +1457,43 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
       <ul
         class="c4"
       >
-        <button
-          class="sc-pscky c5"
+        <li
+          class="c5"
         >
-          ?
-        </button>
-        <button
-          class="sc-pscky c5"
+          <button
+            class="sc-pscky c6"
+          >
+            ?
+          </button>
+        </li>
+        <li
+          class="c5"
         >
-          x
-        </button>
+          <button
+            class="sc-pscky c6"
+          >
+            x
+          </button>
+        </li>
       </ul>
     </div>
     <div
-      class="c6"
+      class="c7"
     />
   </div>
   <div
-    class="c9"
+    class="c10"
     display="flex"
     height="28"
     width="100%"
   >
     <button
-      class="c10"
+      class="c11"
       height="auto"
       width="auto"
     >
       <i
-        class="c11"
+        class="c12"
         data-icon-name="logo"
         height="20"
         style="margin-right: 4px; background-image: url(buffer-32-4-1);"
@@ -1464,56 +1502,56 @@ exports[`<TaskBar /> Snapshots should match snapshot with two Modals 1`] = `
       Start
     </button>
     <div
-      class="c12"
+      class="c13"
       display="flex"
       height="auto"
       width="100%"
     >
       <button
-        class="c13"
+        class="c14"
         height="auto"
         width="auto"
       >
         <i
-          class="c11"
+          class="c12"
           data-icon-name="windows_explorer"
           height="20"
           style="margin-right: 4px; background-image: url(buffer-32-4-1);"
           width="20"
         />
         <span
-          class="c14"
+          class="c15"
         >
           Windows Explorer
         </span>
       </button>
       <button
-        class="c15"
+        class="c16"
         height="auto"
         width="auto"
       >
         <i
-          class="c11"
+          class="c12"
           data-icon-name="bat"
           height="20"
           style="margin-right: 4px; background-image: url(buffer-32-4-1);"
           width="20"
         />
         <span
-          class="c14"
+          class="c15"
         >
           file.bat
         </span>
       </button>
     </div>
     <div
-      class="c16"
+      class="c17"
       height="auto"
       style="display: flex; justify-content: center; align-items: center;"
       width="auto"
     >
       <div
-        class="c17 c18"
+        class="c18 c19"
       >
         
       </div>

--- a/packages/core/components/Tooltip/__snapshots__/Tooltip.snap
+++ b/packages/core/components/Tooltip/__snapshots__/Tooltip.snap
@@ -22,7 +22,7 @@ exports[`<Tooltip /> Snapshot should match snapshot 1`] = `
 exports[`<Tooltip /> Snapshot should match snapshot 2`] = `
 <div>
   <div
-    class="sc-pzYib fzdhZo"
+    class="sc-pItiW cPLUaX"
   >
     .c0 {
   background-color: #c3c7cb;
@@ -42,7 +42,7 @@ exports[`<Tooltip /> Snapshot should match snapshot 2`] = `
 }
 
 <div
-      class="sc-qPlga c0"
+      class="sc-qXhiz c0"
       height="auto"
       width="auto"
     >

--- a/packages/core/components/Video/__snapshots__/Video.snap
+++ b/packages/core/components/Video/__snapshots__/Video.snap
@@ -358,7 +358,7 @@ exports[`<Video /> Snapshot should match snapshot 1`] = `
           </svg>
         </button>
         <input
-          class="sc-qXhiz c10"
+          class="sc-pzYib c10"
           max="100"
           min="0"
           step="1"


### PR DESCRIPTION
Options Box list does not contain `<li>` and this is a tech debt because screen readers and other assistive technologies depend on lists being structured properly to keep users informed of content within the lists.

This PR fixes this by adding a li (named `OptionItem`) in OptionsBox.

Reference: https://web.dev/list/

_Obs: If this PR is able to participate in Hacktoberfest, add the label `hacktoberfest-accepted` to count in my contributions :)_ 