### PR TITLE
fix: remove s3 CDN and use default github CDN to allow NextJS SSR

### DIFF
--- a/packages/clippy/src/ClippyProvider.jsx
+++ b/packages/clippy/src/ClippyProvider.jsx
@@ -6,8 +6,6 @@ import clippyStyle from './style';
 import AGENTS from './agents';
 import ClippyContext from './ClippyContext';
 
-window.CLIPPY_CDN = '//s3.amazonaws.com/clippy.js/Agents/';
-
 let clippyAgent;
 
 const ClippyProvider = ({ children, agentName = AGENTS.CLIPPY }) => {


### PR DESCRIPTION
fix #218