### PR TITLE
fix: prevent Alert to be displayed in TaskBar as a WindowsButton

### DIFF
--- a/packages/core/components/Alert/Alert.tsx
+++ b/packages/core/components/Alert/Alert.tsx
@@ -42,10 +42,10 @@ const Dialog: DialogProps = Object.assign(
 export type AlertProps = Omit<
   ModalProps,
   'closeModal'
-> & {} & DialogImageProps & {
-    message: string;
-    closeAlert: ModalProps['closeModal'];
-  };
+> & DialogImageProps & {
+  message: string;
+  closeAlert: ModalProps['closeModal'];
+};
 
 const Alert: React.FC<AlertProps> = ({
   type = 'error',
@@ -53,7 +53,7 @@ const Alert: React.FC<AlertProps> = ({
   closeAlert,
   ...rest
 }) => (
-  <Modal closeModal={closeAlert} height="120" {...rest}>
+  <Modal closeModal={closeAlert} height="120" hasWindowButton={false} {...rest}>
     <Dialog>
       <Dialog.Image name={DialogImages[type] as IconProps['name']} />
       <Dialog.Message>{message}</Dialog.Message>

--- a/packages/core/components/Modal/Modal.tsx
+++ b/packages/core/components/Modal/Modal.tsx
@@ -189,12 +189,14 @@ export type ModalProps = {
   buttons?: Array<ModalButtons>;
   menu?: Array<ModalMenu>;
   defaultPosition?: ModalDefaultPosition;
+  hasWindowButton?: boolean;
 } & Omit<WrapperProps, 'active'> &
   ButtonWrapperProps &
   React.HTMLAttributes<HTMLDivElement>;
 
 const ModalRenderer = (
   {
+    hasWindowButton = true,
     buttons,
     buttonsAlignment,
     children,
@@ -218,7 +220,7 @@ const ModalRenderer = (
   const [menuOpened, setMenuOpened] = React.useState('');
 
   React.useEffect(() => {
-    addWindows({ icon, title });
+    addWindows({ icon, title, hasButton: hasWindowButton });
     setActiveWindow(title);
     return () => removeWindows(title);
   }, []);

--- a/packages/core/components/Modal/ModalContext.ts
+++ b/packages/core/components/Modal/ModalContext.ts
@@ -6,6 +6,7 @@ import { IconProps } from '../Icon/Icon';
 export type Windows = {
   icon?: IconProps['name'];
   title: string;
+  hasButton: boolean;
 };
 
 export interface IModalContextProps {

--- a/packages/core/components/TaskBar/TaskBar.tsx
+++ b/packages/core/components/TaskBar/TaskBar.tsx
@@ -73,7 +73,7 @@ const TaskBar: React.FC<TaskBarProps> = ({ list }) => {
         display="flex"
       >
         {windows &&
-          windows.map(({ icon, title }, index) => (
+          windows.map(({ icon, title, hasButton }, index) => hasButton && (
             <WindowButton
               key={`${title}-${index}`}
               icon={icon}


### PR DESCRIPTION
Fixes https://github.com/React95/React95/issues/155

This adds an extra `hasWindowButton` prop to the Modal component. ✨