### PR TITLE
chore: Make Bojagi run on every commit/branch

### DIFF
--- a/.github/workflows/bojagi.yml
+++ b/.github/workflows/bojagi.yml
@@ -1,15 +1,11 @@
-name: React95 - Publish workflow
+name: React95 - Bojagi workflow
 
 on:
-  push:
-    branches:
-      - master
-      - alpha
+  push
 
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.head_commit.message, 'Merge')
     steps:
       - uses: actions/checkout@v2
         with:
@@ -27,20 +23,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Install dependencies
         run: yarn --pure-lockfile --non-interactive
-      - name: Lint
-        run: yarn lint:all
-      - name: Test
-        run: yarn test
-      - name: Build
+      - name: Bojagi
         run: |
-          yarn build
-      - name: Publish
-        run: |
-          GH_TOKEN=${GH_TOKEN}
-          NPM_TOKEN=${NPM_TOKEN}
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ./.npmrc
-          chmod +x ./scripts/publish
-          ./scripts/publish
+          BOJAGI_SECRET=${BOJAGI_SECRET}
+          yarn bojagi:core
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          BOJAGI_SECRET: ${{ secrets.BOJAGI_SECRET }}


### PR DESCRIPTION
Until now Bojagi was just running on master and alpha branches.
To really take the most out of it it should run on every commit so you can review PR changes.
I made a separate job that only builds Bojagi without any branch restrictions and removed it from the build and deploy job.