### PR TITLE
Fix icons assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-plugin-styled-components": "^1.10.7",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-modern-regexp": "0.0.6",
+    "babel-plugin-inline-import-data-uri": "^1.0.1",
     "babel-polyfill": "^6.26.0",
     "commitizen": "^4.0.3",
     "cross-env": "^7.0.2",

--- a/packages/core/babel.config.js
+++ b/packages/core/babel.config.js
@@ -6,7 +6,7 @@ module.exports = {
     [
       'inline-import-data-uri',
       {
-        extensions: ['.mp3'],
+        extensions: ['.mp3', '.svg', '.png'],
       },
     ],
   ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,6 @@
     "@types/styled-system": "^5.1.10",
     "@types/xstyled__styled-components": "^1.17.0",
     "@types/xstyled__system": "^1.17.1",
-    "babel-plugin-inline-import-data-uri": "^1.0.1",
     "copy-to-clipboard": "^3.3.1",
     "fs-extra": "^9.0.0",
     "rimraf": "^3.0.2",

--- a/packages/icons/babel.config.js
+++ b/packages/icons/babel.config.js
@@ -1,4 +1,12 @@
 module.exports = {
   extends: '../../babel.config.js',
   ignore: ['**/*.d.ts'],
+  plugins: [
+    [
+      'inline-import-data-uri',
+      {
+        extensions: ['.png'],
+      },
+    ],
+  ],
 };


### PR DESCRIPTION
Just an experiment that can be true, if it fits well

This PR adds a babel plugin to transforms PNG files into `base64` making @react95/icons work without any loader

cc @kirkobyte @breno-felipe 