### PR TITLE
fix(icons): add postbuild copy command to move png files into dist

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -34,6 +34,7 @@
     "build:esm": "cross-env NODE_ENV=esm yarn babel ./src --out-dir dist/esm --extensions .ts,.tsx",
     "build:cjs": "cross-env NODE_ENV=cjs yarn babel ./src --out-dir dist/cjs --extensions .ts,.tsx",
     "build:css": "cp ./icons.css ./dist/icons.css",
+    "postbuild": "cp -r ./png ./dist/png",
     "prepublish": "yarn build",
     "prepublishOnly": "node ../../scripts/prepublish.js --types"
   },

--- a/packages/icons/processIcons.ts
+++ b/packages/icons/processIcons.ts
@@ -27,8 +27,8 @@ const CSS_FILE_PATH = './icons.css';
 
 const makeCssClass = (icon: IconData) => `
 .${icon.id} {
-  width: ${icon.width};
-  height: ${icon.height};
+  width: ${icon.width}px;
+  height: ${icon.height}px;
   background-image: url(${icon.filePath});
 }
 `;


### PR DESCRIPTION
Fixes the bug where png files weren't available in the bundle since they weren't copied into the
dist folder

fix #259 #253