### PR TITLE
fix(modal): update taskbar icon and text on modal change

### DIFF
--- a/packages/core/components/Modal/Modal.test.tsx
+++ b/packages/core/components/Modal/Modal.test.tsx
@@ -97,11 +97,10 @@ describe('<Modal />', () => {
       const { container } = await waitRender(
         <ModalContext.Provider
           value={{
-            windows: [],
+            windows: {},
             addWindows: () => {},
-            removeWindows: () => {},
+            removeWindow: () => {},
             setActiveWindow: () => {},
-            removeWindowById: () => {},
             updateWindow: () => {},
             activeWindow: '',
           }}

--- a/packages/core/components/Modal/Modal.test.tsx
+++ b/packages/core/components/Modal/Modal.test.tsx
@@ -101,6 +101,8 @@ describe('<Modal />', () => {
             addWindows: () => {},
             removeWindows: () => {},
             setActiveWindow: () => {},
+            removeWindowById: () => {},
+            updateWindow: () => {},
             activeWindow: '',
           }}
         >

--- a/packages/core/components/Modal/Modal.tsx
+++ b/packages/core/components/Modal/Modal.tsx
@@ -218,7 +218,7 @@ const ModalRenderer = (
 ) => {
   const {
     addWindows,
-    removeWindowById,
+    removeWindow,
     updateWindow,
     setActiveWindow,
     activeWindow,
@@ -240,7 +240,7 @@ const ModalRenderer = (
   React.useEffect(() => {
     return () => {
       if (id) {
-        removeWindowById(id);
+        removeWindow(id);
       }
     };
   }, [id]);

--- a/packages/core/components/Modal/Modal.tsx
+++ b/packages/core/components/Modal/Modal.tsx
@@ -201,7 +201,7 @@ export type ModalProps = {
 
 const ModalRenderer = (
   {
-    hasWindowButton = true,
+    hasWindowButton: hasButton = true,
     buttons,
     buttonsAlignment,
     children,
@@ -218,17 +218,32 @@ const ModalRenderer = (
 ) => {
   const {
     addWindows,
-    removeWindows,
+    removeWindowById,
+    updateWindow,
     setActiveWindow,
     activeWindow,
   } = React.useContext(ModalContext);
+  const [id, setId] = React.useState<string | null>(null);
   const [menuOpened, setMenuOpened] = React.useState('');
 
   React.useEffect(() => {
-    addWindows({ icon, title, hasButton: hasWindowButton });
-    setActiveWindow(title);
-    return () => removeWindows(title);
-  }, []);
+    if (!id) {
+      const newId = addWindows({ icon, title, hasButton });
+      if (newId) {
+        setId(newId);
+        setActiveWindow(title);
+      }
+    } else {
+      updateWindow(id, { icon, title, hasButton });
+    }
+  }, [id, icon, title, hasButton]);
+  React.useEffect(() => {
+    return () => {
+      if (id) {
+        removeWindowById(id);
+      }
+    };
+  }, [id]);
 
   const isActive = title === activeWindow;
 

--- a/packages/core/components/Modal/Modal.tsx
+++ b/packages/core/components/Modal/Modal.tsx
@@ -231,7 +231,7 @@ const ModalRenderer = (
       const newId = addWindows({ icon, title, hasButton });
       if (newId) {
         setId(newId);
-        setActiveWindow(title);
+        setActiveWindow(newId);
       }
     } else {
       updateWindow(id, { icon, title, hasButton });
@@ -245,7 +245,7 @@ const ModalRenderer = (
     };
   }, [id]);
 
-  const isActive = title === activeWindow;
+  const isActive = id === activeWindow;
 
   return (
     <Draggable handle=".draggable" defaultPosition={defaultPosition}>
@@ -253,7 +253,7 @@ const ModalRenderer = (
         width={width}
         height={height}
         {...rest}
-        onClick={() => setActiveWindow(title)}
+        onClick={id ? () => setActiveWindow(id) : undefined}
         active={isActive}
         ref={ref}
       >

--- a/packages/core/components/Modal/ModalContext.ts
+++ b/packages/core/components/Modal/ModalContext.ts
@@ -10,8 +10,7 @@ export type Windows = {
 export interface IModalContextProps {
   windows: Record<string, Windows>;
   addWindows(window: Windows): string | void;
-  removeWindows(title: string): void;
-  removeWindowById(id: string): void;
+  removeWindow(id: string): void;
   updateWindow(id: string, window: Windows): void;
   setActiveWindow(title: string): void;
   activeWindow?: string;
@@ -20,8 +19,7 @@ export interface IModalContextProps {
 const ModalContext = createContext<IModalContextProps>({
   windows: {},
   addWindows: () => {},
-  removeWindows: () => {},
-  removeWindowById: () => {},
+  removeWindow: () => {},
   updateWindow: () => {},
   setActiveWindow: () => {},
   activeWindow: '',

--- a/packages/core/components/Modal/ModalContext.ts
+++ b/packages/core/components/Modal/ModalContext.ts
@@ -9,8 +9,10 @@ export type Windows = {
 
 export interface IModalContextProps {
   windows: Array<Windows>;
-  addWindows(window: Windows): void;
+  addWindows(window: Windows): string | void;
   removeWindows(title: string): void;
+  removeWindowById(id: string): void;
+  updateWindow(id: string, window: Windows): void;
   setActiveWindow(title: string): void;
   activeWindow?: string;
 }
@@ -19,6 +21,8 @@ const ModalContext = createContext<IModalContextProps>({
   windows: [],
   addWindows: () => {},
   removeWindows: () => {},
+  removeWindowById: () => {},
+  updateWindow: () => {},
   setActiveWindow: () => {},
   activeWindow: '',
 });

--- a/packages/core/components/Modal/ModalContext.ts
+++ b/packages/core/components/Modal/ModalContext.ts
@@ -8,7 +8,7 @@ export type Windows = {
 };
 
 export interface IModalContextProps {
-  windows: Array<Windows>;
+  windows: Record<string, Windows>;
   addWindows(window: Windows): string | void;
   removeWindows(title: string): void;
   removeWindowById(id: string): void;
@@ -18,7 +18,7 @@ export interface IModalContextProps {
 }
 
 const ModalContext = createContext<IModalContextProps>({
-  windows: [],
+  windows: {},
   addWindows: () => {},
   removeWindows: () => {},
   removeWindowById: () => {},

--- a/packages/core/components/Modal/ModalProvider.tsx
+++ b/packages/core/components/Modal/ModalProvider.tsx
@@ -1,26 +1,91 @@
+import { nanoid } from 'nanoid';
 import * as React from 'react';
 
 import ModalContext, { Windows } from './ModalContext';
 
 export type ModalProviderProps = {};
 
-const ModalProvider: React.FunctionComponent<ModalProviderProps> = ({
-  children,
-}) => {
-  const [windows, setWindows] = React.useState<Array<Windows>>([]);
+type WindowStack = Record<string, Windows>;
+
+type WindowAction =
+  | {
+      type: 'ADD_WINDOW';
+      id: string;
+      window: Windows;
+    }
+  | {
+      type: 'UPDATE_WINDOW';
+      id: string;
+      window: Windows;
+    }
+  | {
+      type: 'REMOVE_WINDOW';
+      id: string;
+    }
+  | {
+      type: 'REMOVE_BY_TITLE';
+      title: string;
+    };
+
+const windowStackReducer: React.Reducer<WindowStack, WindowAction> = (
+  state,
+  action,
+) => {
+  const newWindows = { ...state };
+  switch (action.type) {
+    case 'ADD_WINDOW': {
+      newWindows[action.id] = action.window;
+      return newWindows;
+    }
+    case 'REMOVE_WINDOW': {
+      delete newWindows[action.id];
+      return newWindows;
+    }
+    case 'UPDATE_WINDOW': {
+      newWindows[action.id] = action.window;
+      return newWindows;
+    }
+    case 'REMOVE_BY_TITLE': {
+      Object.entries(newWindows).forEach(([id, window]) => {
+        if (window.title === action.title) {
+          delete newWindows[id];
+        }
+      });
+      return newWindows;
+    }
+    default:
+      return state;
+  }
+};
+
+const ModalProvider: React.FunctionComponent = ({ children }) => {
+  const [windows, dispatch] = React.useReducer(windowStackReducer, {});
   const [activeWindow, setActiveWindow] = React.useState<string>();
 
-  const addWindows = (window: Windows) =>
-    setWindows(state => [...state, window]);
-  const removeWindows = (title: string) =>
-    setWindows(state => state.filter(w => w.title !== title));
+  const addWindows = (window: Windows) => {
+    const id = nanoid();
+    dispatch({ type: 'ADD_WINDOW', id, window });
+    return id;
+  };
+  // TODO: Remove this method in the next major release - updating by IDs is more sensible
+  const removeWindows = (title: string) => {
+    dispatch({ type: 'REMOVE_BY_TITLE', title });
+  };
+  const removeWindowById = (id: string) => {
+    dispatch({ type: 'REMOVE_WINDOW', id });
+  };
+  const updateWindow = (id: string, window: Windows) => {
+    dispatch({ type: 'UPDATE_WINDOW', id, window });
+  };
 
   return (
     <ModalContext.Provider
       value={{
-        windows,
+        windows: Object.values(windows),
         addWindows,
         removeWindows,
+        removeWindowById,
+        updateWindow,
         setActiveWindow,
         activeWindow,
       }}

--- a/packages/core/components/Modal/ModalProvider.tsx
+++ b/packages/core/components/Modal/ModalProvider.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import ModalContext, { Windows } from './ModalContext';
 
+// eslint-disable-next-line @typescript-eslint/ban-types
 export type ModalProviderProps = {};
 
 type WindowStack = Record<string, Windows>;
@@ -81,7 +82,7 @@ const ModalProvider: React.FunctionComponent = ({ children }) => {
   return (
     <ModalContext.Provider
       value={{
-        windows: Object.values(windows),
+        windows,
         addWindows,
         removeWindows,
         removeWindowById,

--- a/packages/core/components/Modal/ModalProvider.tsx
+++ b/packages/core/components/Modal/ModalProvider.tsx
@@ -22,10 +22,6 @@ type WindowAction =
   | {
       type: 'REMOVE_WINDOW';
       id: string;
-    }
-  | {
-      type: 'REMOVE_BY_TITLE';
-      title: string;
     };
 
 const windowStackReducer: React.Reducer<WindowStack, WindowAction> = (
@@ -46,14 +42,6 @@ const windowStackReducer: React.Reducer<WindowStack, WindowAction> = (
       newWindows[action.id] = action.window;
       return newWindows;
     }
-    case 'REMOVE_BY_TITLE': {
-      Object.entries(newWindows).forEach(([id, window]) => {
-        if (window.title === action.title) {
-          delete newWindows[id];
-        }
-      });
-      return newWindows;
-    }
     default:
       return state;
   }
@@ -68,11 +56,7 @@ const ModalProvider: React.FunctionComponent = ({ children }) => {
     dispatch({ type: 'ADD_WINDOW', id, window });
     return id;
   };
-  // TODO: Remove this method in the next major release - updating by IDs is more sensible
-  const removeWindows = (title: string) => {
-    dispatch({ type: 'REMOVE_BY_TITLE', title });
-  };
-  const removeWindowById = (id: string) => {
+  const removeWindow = (id: string) => {
     dispatch({ type: 'REMOVE_WINDOW', id });
   };
   const updateWindow = (id: string, window: Windows) => {
@@ -84,8 +68,7 @@ const ModalProvider: React.FunctionComponent = ({ children }) => {
       value={{
         windows,
         addWindows,
-        removeWindows,
-        removeWindowById,
+        removeWindow,
         updateWindow,
         setActiveWindow,
         activeWindow,

--- a/packages/core/components/TaskBar/TaskBar.tsx
+++ b/packages/core/components/TaskBar/TaskBar.tsx
@@ -73,21 +73,20 @@ const TaskBar: React.FC<TaskBarProps> = ({ list }) => {
         ml={2}
         display="flex"
       >
-        {windows &&
-          windows.map(
-            ({ icon, title, hasButton }, index) =>
-              hasButton && (
-                <WindowButton
-                  key={`${title}-${index}`}
-                  icon={icon}
-                  active={title === activeWindow}
-                  onClick={() => setActiveWindow(title)}
-                  small={false}
-                >
-                  <Truncate>{title}</Truncate>
-                </WindowButton>
-              ),
-          )}
+        {Object.entries(windows).map(
+          ([windowId, { icon, title, hasButton }]) =>
+            hasButton && (
+              <WindowButton
+                key={windowId}
+                icon={icon}
+                active={windowId === activeWindow}
+                onClick={() => setActiveWindow(windowId)}
+                small={false}
+              >
+                <Truncate>{title}</Truncate>
+              </WindowButton>
+            ),
+        )}
       </Frame>
 
       <Clock />

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
     "@types/react-virtualized": "^9.21.10",
     "@xstyled/styled-components": "^1.17.1",
     "csstype": "^3.0.3",
+    "nanoid": "^3.1.22",
     "react-draggable": "^4.3.1",
     "styled-system": "^5.1.5",
     "typescript": "^3.9.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11643,6 +11643,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
+nanoid@^3.1.22:
+  version "3.1.22"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844"
+  integrity sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
Makes the ModalProvider state update as required for modal titles and icons to be updated in the
taskbar if they're changed in the modals.

Also fixes the bug that would remove all instances of a modal with the same title when one is removed.

IDs were added to the modals, and used to reference removal and/or update of modals. For backwards compatibility, if anyone's using the modal provider directly, I've kept the current method for removing modals as-is

fixes: #231