### PR TITLE
fix(TaskBar): add alt attribute in logo

### DIFF
--- a/packages/core/components/TaskBar/TaskBar.tsx
+++ b/packages/core/components/TaskBar/TaskBar.tsx
@@ -57,7 +57,7 @@ const TaskBar = forwardRef<HTMLDivElement, TaskBarProps>(({ list }, ref) => {
       )}
       <WindowButton
         small
-        icon={<Logo variant="32x32_4" />}
+        icon={<Logo variant="32x32_4" alt="Windows95 Logo" />}
         active={activeStart}
         onClick={() => {
           toggleActiveStart(!activeStart);


### PR DESCRIPTION
The lighthouse reports an error on the SEO topic because the logo in TaskBar doesn't have `alt` attribute. This PR fixes it.
![image](https://user-images.githubusercontent.com/41922744/121521171-1ce0bf80-c9ca-11eb-8bbc-e41dc82d7c05.png)
