### PR TITLE
feat(modal): instant activation of modal on click rather than on mouseUp

### DIFF
--- a/packages/core/components/Modal/Modal.tsx
+++ b/packages/core/components/Modal/Modal.tsx
@@ -250,7 +250,11 @@ const ModalRenderer = (
   React.useEffect(() => setIsActive(id === activeWindow), [id, activeWindow]);
 
   return (
-    <Draggable handle=".draggable" defaultPosition={defaultPosition} onMouseDown={id ? () => setActiveWindow(id) : undefined}>
+    <Draggable
+      handle=".draggable"
+      defaultPosition={defaultPosition}
+      onMouseDown={id ? () => setActiveWindow(id) : undefined}
+    >
       <ModalWrapper
         width={width}
         height={height}

--- a/packages/core/components/Modal/Modal.tsx
+++ b/packages/core/components/Modal/Modal.tsx
@@ -227,6 +227,7 @@ const ModalRenderer = (
   } = React.useContext(ModalContext);
   const [id, setId] = React.useState<string | null>(null);
   const [menuOpened, setMenuOpened] = React.useState('');
+  const [isActive, setIsActive] = React.useState(false);
 
   React.useEffect(() => {
     if (!id) {
@@ -246,16 +247,14 @@ const ModalRenderer = (
       }
     };
   }, [id]);
-
-  const isActive = id === activeWindow;
+  React.useEffect(() => setIsActive(id === activeWindow), [id, activeWindow]);
 
   return (
-    <Draggable handle=".draggable" defaultPosition={defaultPosition}>
+    <Draggable handle=".draggable" defaultPosition={defaultPosition} onMouseDown={id ? () => setActiveWindow(id) : undefined}>
       <ModalWrapper
         width={width}
         height={height}
         {...rest}
-        onClick={id ? () => setActiveWindow(id) : undefined}
         active={isActive}
         ref={ref}
       >

--- a/packages/core/stories/modal.stories.tsx
+++ b/packages/core/stories/modal.stories.tsx
@@ -4,7 +4,9 @@ import { Meta } from '@storybook/react/types-6-0';
 import { Modal } from '../components/Modal';
 import Button from '../components/Button';
 import List from '../components/List';
-import { Computer } from '@react95/icons';
+import Frame from '../components/Frame';
+
+import { Computer, Mshtml32534, Mmsys113 } from '@react95/icons';
 
 export default {
   title: 'Modal',
@@ -67,4 +69,118 @@ Simple.parameters = {
     url:
       'https://www.figma.com/file/2cbigNitjcruBDZT12ixIq/React95-Design-Kit?node-id=3%3A12',
   },
+};
+
+export const Multiple = () => {
+  const [showFirstModal, toggleShowFirstModal] = React.useState(false);
+  const [showSecondModal, toggleShowSecondModal] = React.useState(false);
+
+  const handleOpenBothModals = () => {
+    toggleShowFirstModal(true);
+    toggleShowSecondModal(true);
+  };
+  const handleOpenFirstModal = () => toggleShowFirstModal(true);
+  const handleOpenSecondModal = () => toggleShowSecondModal(true);
+  const handleCloseFirstModal = () => toggleShowFirstModal(false);
+  const handleCloseSecondModal = () => toggleShowSecondModal(false);
+  const handleButtonClick = (e: React.MouseEvent<HTMLLIElement>) =>
+    alert(e.currentTarget.value);
+
+  return (
+    <>
+      <Button onClick={handleOpenBothModals}>Trigger Both</Button>
+      <Button onClick={handleOpenFirstModal}>Trigger 1st</Button>
+      <Button onClick={handleOpenSecondModal}>Trigger 2nd</Button>
+      {showFirstModal && (
+        <Modal
+          width="300"
+          height="200"
+          icon={<Mmsys113 variant="32x32_4" />}
+          title="First Modal"
+          defaultPosition={{
+            x: 0,
+            y: 20,
+          }}
+          closeModal={handleCloseFirstModal}
+          buttons={[
+            { value: 'Ok', onClick: handleButtonClick },
+            { value: 'Cancel', onClick: handleButtonClick },
+          ]}
+          menu={[
+            {
+              name: 'File',
+              list: (
+                <List>
+                  <List.Item onClick={handleCloseFirstModal}>Exit</List.Item>
+                </List>
+              ),
+            },
+            {
+              name: 'Edit',
+              list: (
+                <List>
+                  <List.Item>Copy</List.Item>
+                </List>
+              ),
+            },
+          ]}
+        >
+          <Frame
+            bg="white"
+            boxShadow="in"
+            height="100%"
+            width="100%"
+            padding="0px 5px"
+          >
+            <p>The active modal will be based on the order they render, most recently rendered will be the active component. On click of a non-active modal will fire an action to set that modal as the active one.</p>
+          </Frame>
+        </Modal>
+      )}
+      {showSecondModal && (
+        <Modal
+          width="300"
+          height="200"
+          icon={<Mshtml32534 variant="32x32_4" />}
+          title="Second Modal"
+          defaultPosition={{
+            x: 250,
+            y: 100,
+          }}
+          closeModal={handleCloseSecondModal}
+          buttons={[
+            { value: 'Ok', onClick: handleButtonClick },
+            { value: 'Cancel', onClick: handleButtonClick },
+          ]}
+          menu={[
+            {
+              name: 'File',
+              list: (
+                <List>
+                  <List.Item onClick={handleCloseSecondModal}>Exit</List.Item>
+                </List>
+              ),
+            },
+            {
+              name: 'Edit',
+              list: (
+                <List>
+                  <List.Item>Copy</List.Item>
+                </List>
+              ),
+            },
+          ]}
+        >
+          <Frame
+            bg="white"
+            boxShadow="in"
+            height="100%"
+            width="100%"
+            padding="0px 5px"
+          >
+            <p>Try playing with the modals. See which on is active, click and drag them. Understand their behavior.</p>
+          </Frame>
+        </Modal>
+      )}
+    </>
+  );
 };


### PR DESCRIPTION
Existing code doesn't activate modal until user releases their mouse click. This causes the modal
dragging to be behind the currently active modal. This fix/feature immediately activates the modal
window on click, allowing it to drag in front of all other modals.

* Also adds a "Multiple" story to the Modal section of Storybook, demonstrating how the changes work