### PR TITLE
chore: update LRNZ09 profile url

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -163,7 +163,7 @@
       "login": "LRNZ09",
       "name": "Lorenzo Pieri",
       "avatar_url": "https://avatars2.githubusercontent.com/u/13508373?v=4",
-      "profile": "https://lorenzopieri.dev",
+      "profile": "https://github.com/LRNZ09",
       "contributions": [
         "doc"
       ]


### PR DESCRIPTION
Replace my profile URL from the personal website to the GitHub profile.