### PR TITLE
(WIP) Allow Tree FolderStatus boxes to have a custom size for Mobile

### DIFF
--- a/packages/core/components/Tree/Node.tsx
+++ b/packages/core/components/Tree/Node.tsx
@@ -49,12 +49,12 @@ const NodeInfo = styled.div`
   -ms-user-select: none;
 `;
 
-const FolderStatus = styled.div`
+const FolderStatus = styled.div<{size: number}>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 10px;
-  height: 10px;
+  width: ${size || '10'}px;
+  height: ${size || '10'}px;
   border: 1;
   border-color: borderDarkest;
   background-color: inputBackground;
@@ -116,6 +116,7 @@ const NodeIcon: React.FC<{ hasChildren: boolean; isOpen: boolean }> = ({
 export type NodeProps = {
   label: string;
   icon?: React.ReactElement;
+  folderStatusSize?: number;
   id: number;
   children?: Array<NodeProps>;
   onClick?(
@@ -129,6 +130,7 @@ const Node: React.FC<NodeProps> = ({
   id,
   icon,
   label,
+  folderStatusSize,
   onClick = () => {},
   ...rest
 }) => {
@@ -155,7 +157,7 @@ const Node: React.FC<NodeProps> = ({
     <NodeItem isOpen={isOpen} {...rest}>
       <NodeInfo>
         {hasChildren && (
-          <FolderStatus onClick={() => setIsOpen(!isOpen)}>
+          <FolderStatus size={folderStatusSize} onClick={() => setIsOpen(!isOpen)}>
             {isOpen ? '-' : '+'}
           </FolderStatus>
         )}


### PR DESCRIPTION
WIP - I want to have the ability to change the size of the folderStatus Box for mobile users. I'd rather have a larger target field and off-margins than too small of a target box for users to tap.