### PR TITLE
Update react95/core peerdependencies to 6.0.4 on gastby-theme

### DIFF
--- a/packages/gatsby-theme/package.json
+++ b/packages/gatsby-theme/package.json
@@ -42,7 +42,7 @@
     "ts-loader": "^9.2.8"
   },
   "peerDependencies": {
-    "@react95/core": "^5.5.0",
+    "@react95/core": "^6.0.4",
     "@xstyled/styled-components": "^3.5.1",
     "gatsby": "^4.11.0",
     "react": "^17.0.2",


### PR DESCRIPTION
Fixes https://github.com/React95/React95/issues/351
Fixes with latest version of gatsby