### PR TITLE
fix(clippy): broken dependecy url

### DIFF
--- a/packages/clippy/src/ClippyProvider.jsx
+++ b/packages/clippy/src/ClippyProvider.jsx
@@ -46,7 +46,7 @@ const ClippyProvider = ({ children, agentName = AGENTS.CLIPPY }) => {
         () => {
           setClippy();
         },
-        window.CLIPPY_CDN || 'https://gitcdn.xyz/repo/pi0/clippyjs/master/assets/agents/',
+        window?.CLIPPY_CDN || 'https://cdn.jsdelivr.net/pi0/clippyjs/master/assets/agents/',
       );
     }
 

--- a/packages/clippy/src/ClippyProvider.jsx
+++ b/packages/clippy/src/ClippyProvider.jsx
@@ -6,8 +6,6 @@ import clippyStyle from './style';
 import AGENTS from './agents';
 import ClippyContext from './ClippyContext';
 
-if (typeof window !== "undefined") window.CLIPPY_CDN = '//s3.amazonaws.com/clippy.js/Agents/';
-
 let clippyAgent;
 
 const ClippyProvider = ({ children, agentName = AGENTS.CLIPPY }) => {
@@ -48,6 +46,7 @@ const ClippyProvider = ({ children, agentName = AGENTS.CLIPPY }) => {
         () => {
           setClippy();
         },
+        window.CLIPPY_CDN || 'https://gitcdn.xyz/repo/pi0/clippyjs/master/assets/agents/',
       );
     }
 


### PR DESCRIPTION
Currently, Clippy is broken on every page using this package, because the referenced S3 Bucket has been deleted. Unfortunately, there is also no way to overwrite the CDN URL from the outside to fix this issue directly.

My proposed change addresses both of these situations:
* By passing the `baseUrl` into the `clippy.load` function, we avoid declaring the unnecessary global parameter. I have updated the default value to the gitcdn value that the author of the npm package uses itself.
* By using the `||` or, we allow any page to declare their own path by specifying `window.CLIPPY_CDN` themselves.