### PR TITLE
fix(jsdelivr): correct CLIPPY_CDN

### DIFF
--- a/packages/clippy/src/ClippyProvider.jsx
+++ b/packages/clippy/src/ClippyProvider.jsx
@@ -46,7 +46,7 @@ const ClippyProvider = ({ children, agentName = AGENTS.CLIPPY }) => {
         () => {
           setClippy();
         },
-        window?.CLIPPY_CDN || 'https://cdn.jsdelivr.net/pi0/clippyjs/master/assets/agents/',
+        window?.CLIPPY_CDN || 'https://cdn.jsdelivr.net/gh/pi0/clippyjs@master/assets/agents/',
       );
     }
 


### PR DESCRIPTION
The old cdn url resulted in png paths like https://cdn.jsdelivr.net/pi0/clippyjs/master/assets/agents/Clippy/map.png which does not resolve - I guess this is an old jsdelivr URL scheme? The original clippyjs uses gitcdn.xyz which doesn't seem to exist at all.

With this update the png path is https://cdn.jsdelivr.net/gh/pi0/clippyjs@master/assets/agents/Clippy/map.png which is correct.

Docs: https://github.com/jsdelivr/jsdelivr#github

Users can work around this by setting `window.CLIPPY_CDN` manually, but may as well make it work out of the box. (Separate issue - error messages are silently swallowed so this kind of thing is tricky to debug right now).