### PR TITLE
Updating Video event handlers

### DIFF
--- a/packages/core/.storybook/src/theme-changer/register.js
+++ b/packages/core/.storybook/src/theme-changer/register.js
@@ -53,8 +53,8 @@ addons.register(ADDON_ID, api => {
   addons.add(PANEL_ID, {
     type: types.PANEL,
     title: 'Themes',
-    render: ({ active, key }) => (
-      <AddonPanel active={active} key={key}>
+    render: ({ active }) => (
+      <AddonPanel active={active}>
         <ThemePanel api={api} />
       </AddonPanel>
     ),

--- a/packages/core/components/Video/Video.test.tsx
+++ b/packages/core/components/Video/Video.test.tsx
@@ -109,17 +109,6 @@ describe('<Video />', () => {
     });
 
     it('should update video when range updates', async () => {
-      class ExtendableMouseEvent extends MouseEvent {
-        constructor(type: string, values: Partial<MouseEvent>) {
-          const { offsetX, ...mouseValues } = values;
-          super(type, { ...mouseValues, bubbles: true, cancelable: true });
-
-          Object.assign(this, {
-            offsetX: offsetX || 0,
-          });
-        }
-      }
-
       const { container } = await waitRender(
         <Video src="foo/bar/some_video.mp4" />,
       );
@@ -131,19 +120,16 @@ describe('<Video />', () => {
       video.currentTime = 0;
 
       const videoRange = container.querySelector('input')!;
-      // @ts-ignore
-      videoRange.offsetWidth = 100;
 
       expect(videoRange.value).toBe('0');
 
       act(() => {
-        fireEvent(
-          videoRange,
-          new ExtendableMouseEvent('click', {
+        fireEvent.change(videoRange, {
+          target: {
             // forward 10%
-            offsetX: 10,
-          }),
-        );
+            value: 10,
+          },
+        });
       });
 
       expect(video.currentTime).toBeGreaterThan(0);

--- a/packages/core/components/Video/Video.tsx
+++ b/packages/core/components/Video/Video.tsx
@@ -321,16 +321,16 @@ const VideoRenderer = (
               width: '70%',
               marginLeft: 20,
             }}
-            onClick={e => {
-              const { current: el } = progressRef;
+            onChange={({ target }) => {
               const { current: video } = player;
 
-              if (video && el) {
-                const percent = e.nativeEvent.offsetX / el.offsetWidth;
+              if (video) {
+                const value = parseInt(target.value);
+                const percent = value / 100;
 
                 video.currentTime = percent * video.duration;
 
-                setProgress(Math.floor(percent / 100));
+                setProgress(value);
               }
             }}
           />

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,6 @@
     "nanoid": "^3.3.1",
     "react-draggable": "^4.4.4",
     "styled-system": "^5.1.5",
-    "typescript": "^4.6.2",
     "url-loader": "^4.1.1"
   },
   "peerDependencies": {
@@ -53,6 +52,7 @@
     "rimraf": "^3.0.2",
     "storybook": "^7.4.6",
     "styled-components": "^5.3.3",
+    "typescript": "5.3.3",
     "vite": "^4.3.8"
   },
   "scripts": {

--- a/packages/icons/babel.config.js
+++ b/packages/icons/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   extends: '../../babel.config.js',
-  ignore: ['**/*.d.ts'],
+  ignore: ['**/*.d.ts', 'src/iconDemos.ts'],
 };

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -47,6 +47,6 @@
     "pixel-perfect-svg": "^0.1.0",
     "svgo": "^3.2.0",
     "ts-node": "^10.7.0",
-    "typescript": "^4.6.2"
+    "typescript": "5.3.3"
   }
 }

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -12,5 +12,6 @@
       "@andreekeberg/imagedata": ["./scripts/imagedata.d.ts"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/iconDemos.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
-    "lib": ["es2019", "dom"],
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "sourceMap": true,
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13104,15 +13104,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-"typescript@>=3 < 6":
+typescript@5.3.3, "typescript@>=3 < 6":
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
-
-typescript@^4.6.2:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 ufo@^1.3.0, ufo@^1.3.2:
   version "1.3.2"


### PR DESCRIPTION
To get #409 fixed, we removed the `onClick` handler from the Video#range and added an `onChange` instead.

I'm also taking advantage of this and fixing some dependencies mismatching.

This PR fix #409 