### PR TITLE
fix(core): `GlobalStyle` and `themes` are missing after build

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,12 +12,12 @@
     },
     "./themes/*.css": {
       "types": "./types/themes/all.d.ts",
-      "import": "./esm/themes/*.css.mjs",
-      "require": "./cjs/themes/*.css.cjs"
+      "import": "./esm/themes/*.css.ts.vanilla.css",
+      "require": "./cjs/themes/*.css.ts.vanilla.css"
     },
     "./GlobalStyle": {
-      "import": "./esm/GlobalStyle.mjs",
-      "require": "./cjs/GlobalStyle.cjs"
+      "import": "./esm/GlobalStyle/GlobalStyle.css.ts.vanilla.css",
+      "require": "./cjs/GlobalStyle/GlobalStyle.css.ts.vanilla.css"
     }
   },
   "repository": {


### PR DESCRIPTION
I think I know why this was happening:

| Before | After |
| ------- | ----- |
| <pre lang="json">"./themes/\*.css": { &#13;  "types": "./types/themes/all.d.ts", &#13;  "import": "./esm/themes/\*.css.mjs", &#13;  "require": "./cjs/themes/*.css.cjs" &#13; },&#13;"./GlobalStyle": {&#13;  "import": "./esm/GlobalStyle.mjs", &#13;  "require": "./cjs/GlobalStyle.cjs" &#13;} </pre> | <pre lang="json">"./themes/\*.css": { &#13;  "types": "./types/themes/all.d.ts",&#13;  "import": "./esm/themes/\*.css.ts.vanilla.css",&#13;  "require": "./cjs/themes/*.css.ts.vanilla.css"&#13;},&#13;"./GlobalStyle": {&#13;  "import": "./esm/GlobalStyle/GlobalStyle.css.ts.vanilla.css",&#13;  "require": "./cjs/GlobalStyle/GlobalStyle.css.ts.vanilla.css"&#13;}</pre> |

So, as you can see, the before column targets the import to a module and this doesn't seem to work when you do the import as
```js
import '@react95/core/GlobalStyle';
import '@react95/core/themes/win95.css';
```

To fix this, we're now targeting the `CSS` file directly so that when you do
```js
import '@react95/core/GlobalStyle';
```
It will target the global style CSS file instead of the global style module file.