### PR TITLE
feat: Exporting each component in `exports` field

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,126 @@
     "./GlobalStyle": {
       "import": "./esm/GlobalStyle/GlobalStyle.css.ts.vanilla.css",
       "require": "./cjs/GlobalStyle/GlobalStyle.css.ts.vanilla.css"
+    },
+    "./Alert": {
+      "import": "./esm/Alert/Alert.mjs",
+      "require": "./cjs/Alert/Alert.cjs",
+      "types": "./types/Alert/Alert.d.ts"
+    },
+    "./Button": {
+      "import": "./esm/Button/Button.mjs",
+      "require": "./cjs/Button/Button.cjs",
+      "types": "./types/Button/Button.d.ts"
+    },
+    "./Checkbox": {
+      "import": "./esm/Checkbox/Checkbox.mjs",
+      "require": "./cjs/Checkbox/Checkbox.cjs",
+      "types": "./types/Checkbox/Checkbox.d.ts"
+    },
+    "./Cursor": {
+      "import": "./esm/Cursor/Cursor.css.mjs",
+      "require": "./cjs/Cursor/Cursor.css.cjs",
+      "types": "./types/Cursor/Cursor.css.d.ts"
+    },
+    "./Dropdown": {
+      "import": "./esm/Dropdown/Dropdown.mjs",
+      "require": "./cjs/Dropdown/Dropdown.cjs",
+      "types": "./types/Dropdown/Dropdown.d.ts"
+    },
+    "./Fieldset": {
+      "import": "./esm/Fieldset/Fieldset.mjs",
+      "require": "./cjs/Fieldset/Fieldset.cjs",
+      "types": "./types/Fieldset/Fieldset.d.ts"
+    },
+    "./Frame": {
+      "import": "./esm/Frame/Frame.mjs",
+      "require": "./cjs/Frame/Frame.cjs",
+      "types": "./types/Frame/Frame.d.ts"
+    },
+    "./Input": {
+      "import": "./esm/Input/Input.mjs",
+      "require": "./cjs/Input/Input.cjs",
+      "types": "./types/Input/Input.d.ts"
+    },
+    "./List": {
+      "import": "./esm/List/List.mjs",
+      "require": "./cjs/List/List.cjs",
+      "types": "./types/List/List.d.ts"
+    },
+    "./ListDivider": {
+      "import": "./esm/ListDivider/ListDivider.mjs",
+      "require": "./cjs/ListDivider/ListDivider.cjs",
+      "types": "./types/ListDivider/ListDivider.d.ts"
+    },
+    "./ListItem": {
+      "import": "./esm/ListItem/ListItem.mjs",
+      "require": "./cjs/ListItem/ListItem.cjs",
+      "types": "./types/ListItem/ListItem.d.ts"
+    },
+    "./Modal": {
+      "import": "./esm/Modal/Modal.mjs",
+      "require": "./cjs/Modal/Modal.cjs",
+      "types": "./types/Modal/Modal.d.ts"
+    },
+    "./ModalProvider": {
+      "import": "./esm/Modal/ModalProvider.mjs",
+      "require": "./cjs/Modal/ModalProvider.cjs",
+      "types": "./types/Modal/ModalProvider.d.ts"
+    },
+    "./ProgressBar": {
+      "import": "./esm/ProgressBar/ProgressBar.mjs",
+      "require": "./cjs/ProgressBar/ProgressBar.cjs",
+      "types": "./types/ProgressBar/ProgressBar.d.ts"
+    },
+    "./RadioButton": {
+      "import": "./esm/RadioButton/RadioButton.mjs",
+      "require": "./cjs/RadioButton/RadioButton.cjs",
+      "types": "./types/RadioButton/RadioButton.d.ts"
+    },
+    "./Range": {
+      "import": "./esm/Range/Range.mjs",
+      "require": "./cjs/Range/Range.cjs",
+      "types": "./types/Range/Range.d.ts"
+    },
+    "./Tabs": {
+      "import": "./esm/Tabs/Tabs.mjs",
+      "require": "./cjs/Tabs/Tabs.cjs",
+      "types": "./types/Tabs/Tabs.d.ts"
+    },
+    "./Tab": {
+      "import": "./esm/Tabs/Tab.mjs",
+      "require": "./cjs/Tabs/Tab.cjs",
+      "types": "./types/Tabs/Tab.d.ts"
+    },
+    "./TaskBar": {
+      "import": "./esm/TaskBar/TaskBar.mjs",
+      "require": "./cjs/TaskBar/TaskBar.cjs",
+      "types": "./types/TaskBar/TaskBar.d.ts"
+    },
+    "./TextArea": {
+      "import": "./esm/TextArea/TextArea.mjs",
+      "require": "./cjs/TextArea/TextArea.cjs",
+      "types": "./types/TextArea/TextArea.d.ts"
+    },
+    "./TitleBar": {
+      "import": "./esm/TitleBar/TitleBar.mjs",
+      "require": "./cjs/TitleBar/TitleBar.cjs",
+      "types": "./types/TitleBar/TitleBar.d.ts"
+    },
+    "./Tooltip": {
+      "import": "./esm/Tooltip/Tooltip.mjs",
+      "require": "./cjs/Tooltip/Tooltip.cjs",
+      "types": "./types/Tooltip/Tooltip.d.ts"
+    },
+    "./Tree": {
+      "import": "./esm/Tree/Tree.mjs",
+      "require": "./cjs/Tree/Tree.cjs",
+      "types": "./types/Tree/Tree.d.ts"
+    },
+    "./Video": {
+      "import": "./esm/Video/Video.mjs",
+      "require": "./cjs/Video/Video.cjs",
+      "types": "./types/Video/Video.d.ts"
     }
   },
   "repository": {


### PR DESCRIPTION
So this syntax works too

```js
import { Button } from '@react95/core/Button';
import { Cursor } from '@react95/core/Cursor';
import { List } from '@react95/core/List';
import { TaskBar } from '@react95/core/TaskBar';
```

And this will keep working 

```js
import { Button, Cursor, List, TaskBar } from '@react95/core';
```