### PR TITLE
fix(clippy): building clippy with vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     }
   },
   "dependencies": {
+    "@rollup/plugin-dynamic-import-vars": "^2.1.2",
     "minimist": "^1.2.8",
     "webpack": "^5.73.0"
   },

--- a/packages/clippy/package.json
+++ b/packages/clippy/package.json
@@ -24,9 +24,9 @@
   },
   "scripts": {
     "prebuild": "rimraf ./dist",
-    "build": "yarn build:cjs && yarn build:esm && yarn build:types",
-    "build:esm": "yarn tsc -b ./tsconfig.esm.json",
-    "build:cjs": "yarn tsc -b ./tsconfig.cjs.json",
+    "prebuild:vite": "rimraf ./dist",
+    "build": "yarn build:vite && yarn build:types",
+    "build:vite": "vite build",
     "build:types": "yarn tsc -b ./tsconfig.types.json",
     "lint": "eslint --ext ts,tsx --quiet src tests",
     "prepublish": "yarn build",
@@ -42,8 +42,7 @@
     "rimraf": "^3.0.2"
   },
   "dependencies": {
-    "clippyts": "^1.0.4",
-    "prop-types": "^15.8.1"
+    "clippyts": "^1.0.4"
   },
   "peerDependencies": {
     "react": ">= 16.8.0"

--- a/packages/clippy/tsconfig.cjs.json
+++ b/packages/clippy/tsconfig.cjs.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.production.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "module": "commonjs"
-  }
-}

--- a/packages/clippy/tsconfig.esm.json
+++ b/packages/clippy/tsconfig.esm.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.production.json",
-  "compilerOptions": {
-    "outDir": "dist/esm",
-    "module": "esnext"
-  }
-}

--- a/packages/clippy/vite.config.js
+++ b/packages/clippy/vite.config.js
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vite';
+import dynamicImportVars from '@rollup/plugin-dynamic-import-vars';
+
+import pkg from './package.json';
+
+export default defineConfig({
+  build: {
+    chunkSizeWarningLimit: 1600,
+    lib: {
+      entry: {
+        index: './index.ts',
+      },
+      name: 'Clippy',
+    },
+    minify: false,
+    cssCodeSplit: true,
+    rollupOptions: {
+      external: [
+        ...Object.keys(pkg.devDependencies || {}),
+        ...Object.keys(pkg.peerDependencies || {}),
+        'react',
+        'react/jsx-runtime',
+      ],
+      output: [
+        {
+          dir: 'dist/esm',
+          format: 'es',
+        },
+        {
+          dir: 'dist/cjs',
+          format: 'cjs',
+        },
+      ],
+    },
+  },
+  plugins: [dynamicImportVars()],
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,126 @@
     "./GlobalStyle": {
       "import": "./esm/GlobalStyle/GlobalStyle.css.ts.vanilla.css",
       "require": "./cjs/GlobalStyle/GlobalStyle.css.ts.vanilla.css"
+    },
+    "./Alert": {
+      "types": "./types/Alert/Alert.d.ts",
+      "import": "./esm/Alert/Alert.mjs",
+      "require": "./cjs/Alert/Alert.cjs"
+    },
+    "./Button": {
+      "types": "./types/Button/Button.d.ts",
+      "import": "./esm/Button/Button.mjs",
+      "require": "./cjs/Button/Button.cjs"
+    },
+    "./Checkbox": {
+      "types": "./types/Checkbox/Checkbox.d.ts",
+      "import": "./esm/Checkbox/Checkbox.mjs",
+      "require": "./cjs/Checkbox/Checkbox.cjs"
+    },
+    "./Cursor": {
+      "types": "./types/Cursor/Cursor.css.d.ts",
+      "import": "./esm/Cursor/Cursor.css.mjs",
+      "require": "./cjs/Cursor/Cursor.css.cjs"
+    },
+    "./Dropdown": {
+      "types": "./types/Dropdown/Dropdown.d.ts",
+      "import": "./esm/Dropdown/Dropdown.mjs",
+      "require": "./cjs/Dropdown/Dropdown.cjs"
+    },
+    "./Fieldset": {
+      "types": "./types/Fieldset/Fieldset.d.ts",
+      "import": "./esm/Fieldset/Fieldset.mjs",
+      "require": "./cjs/Fieldset/Fieldset.cjs"
+    },
+    "./Frame": {
+      "types": "./types/Frame/Frame.d.ts",
+      "import": "./esm/Frame/Frame.mjs",
+      "require": "./cjs/Frame/Frame.cjs"
+    },
+    "./Input": {
+      "types": "./types/Input/Input.d.ts",
+      "import": "./esm/Input/Input.mjs",
+      "require": "./cjs/Input/Input.cjs"
+    },
+    "./List": {
+      "types": "./types/List/List.d.ts",
+      "import": "./esm/List/List.mjs",
+      "require": "./cjs/List/List.cjs"
+    },
+    "./ListDivider": {
+      "types": "./types/ListDivider/ListDivider.d.ts",
+      "import": "./esm/ListDivider/ListDivider.mjs",
+      "require": "./cjs/ListDivider/ListDivider.cjs"
+    },
+    "./ListItem": {
+      "types": "./types/ListItem/ListItem.d.ts",
+      "import": "./esm/ListItem/ListItem.mjs",
+      "require": "./cjs/ListItem/ListItem.cjs"
+    },
+    "./Modal": {
+      "types": "./types/Modal/Modal.d.ts",
+      "import": "./esm/Modal/Modal.mjs",
+      "require": "./cjs/Modal/Modal.cjs"
+    },
+    "./ModalProvider": {
+      "types": "./types/Modal/ModalProvider.d.ts",
+      "import": "./esm/Modal/ModalProvider.mjs",
+      "require": "./cjs/Modal/ModalProvider.cjs"
+    },
+    "./ProgressBar": {
+      "types": "./types/ProgressBar/ProgressBar.d.ts",
+      "import": "./esm/ProgressBar/ProgressBar.mjs",
+      "require": "./cjs/ProgressBar/ProgressBar.cjs"
+    },
+    "./RadioButton": {
+      "types": "./types/RadioButton/RadioButton.d.ts",
+      "import": "./esm/RadioButton/RadioButton.mjs",
+      "require": "./cjs/RadioButton/RadioButton.cjs"
+    },
+    "./Range": {
+      "types": "./types/Range/Range.d.ts",
+      "import": "./esm/Range/Range.mjs",
+      "require": "./cjs/Range/Range.cjs"
+    },
+    "./Tabs": {
+      "types": "./types/Tabs/Tabs.d.ts",
+      "import": "./esm/Tabs/Tabs.mjs",
+      "require": "./cjs/Tabs/Tabs.cjs"
+    },
+    "./Tab": {
+      "types": "./types/Tabs/Tab.d.ts",
+      "import": "./esm/Tabs/Tab.mjs",
+      "require": "./cjs/Tabs/Tab.cjs"
+    },
+    "./TaskBar": {
+      "types": "./types/TaskBar/TaskBar.d.ts",
+      "import": "./esm/TaskBar/TaskBar.mjs",
+      "require": "./cjs/TaskBar/TaskBar.cjs"
+    },
+    "./TextArea": {
+      "types": "./types/TextArea/TextArea.d.ts",
+      "import": "./esm/TextArea/TextArea.mjs",
+      "require": "./cjs/TextArea/TextArea.cjs"
+    },
+    "./TitleBar": {
+      "types": "./types/TitleBar/TitleBar.d.ts",
+      "import": "./esm/TitleBar/TitleBar.mjs",
+      "require": "./cjs/TitleBar/TitleBar.cjs"
+    },
+    "./Tooltip": {
+      "types": "./types/Tooltip/Tooltip.d.ts",
+      "import": "./esm/Tooltip/Tooltip.mjs",
+      "require": "./cjs/Tooltip/Tooltip.cjs"
+    },
+    "./Tree": {
+      "types": "./types/Tree/Tree.d.ts",
+      "import": "./esm/Tree/Tree.mjs",
+      "require": "./cjs/Tree/Tree.cjs"
+    },
+    "./Video": {
+      "types": "./types/Video/Video.d.ts",
+      "import": "./esm/Video/Video.mjs",
+      "require": "./cjs/Video/Video.cjs"
     }
   },
   "repository": {
@@ -76,6 +196,7 @@
   "scripts": {
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build -o docs",
+    "postbuild-storybook": "cp -r ../../node_modules/clippyts/dist/agents ./docs/assets",
     "build": "yarn build:vite && yarn build:types",
     "build:vite": "vite build",
     "build:types": "yarn build:types:core && yarn build:types:themes",

--- a/packages/core/vite.config.js
+++ b/packages/core/vite.config.js
@@ -94,9 +94,4 @@ export default defineConfig({
       },
     }),
   ],
-  optimizeDeps: {
-    // clippyts will dynamically import agents and this is why we need to
-    // exclude it from the optimization
-    exclude: ['clippyts'],
-  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2576,7 +2576,18 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@rollup/pluginutils@^5.0.2":
+"@rollup/plugin-dynamic-import-vars@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-dynamic-import-vars/-/plugin-dynamic-import-vars-2.1.2.tgz#cf87cec47b00ab86badecaf39d234052d3be389b"
+  integrity sha512-4lr2oXxs9hcxtGGaK8s0i9evfjzDrAs7ngw28TqruWKTEm0+U4Eljb+F6HXGYdFv8xRojQlrQwV7M/yxeh3yzQ==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    astring "^1.8.5"
+    estree-walker "^2.0.2"
+    fast-glob "^3.2.12"
+    magic-string "^0.30.3"
+
+"@rollup/pluginutils@^5.0.1", "@rollup/pluginutils@^5.0.2":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.1.0.tgz#7e53eddc8c7f483a4ad0b94afb1f7f5fd3c771e0"
   integrity sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==
@@ -4986,6 +4997,11 @@ ast-types@^0.16.1:
   integrity sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==
   dependencies:
     tslib "^2.0.1"
+
+astring@^1.8.5:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/astring/-/astring-1.9.0.tgz#cc73e6062a7eb03e7d19c22d8b0b3451fd9bfeef"
+  integrity sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==
 
 async-limiter@~1.0.0:
   version "1.0.1"
@@ -7442,7 +7458,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.9:
+fast-glob@^3.2.12, fast-glob@^3.2.9:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
   integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
@@ -9883,7 +9899,7 @@ magic-string@^0.30.0, magic-string@^0.30.5:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.15"
 
-magic-string@^0.30.1:
+magic-string@^0.30.1, magic-string@^0.30.3:
   version "0.30.11"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.11.tgz#301a6f93b3e8c2cb13ac1a7a673492c0dfd12954"
   integrity sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==


### PR DESCRIPTION
Clippy isn't working. This PR fixes it 🩹 

To give more context, our `@react95/clippy` has been using [clippyts](https://github.com/lizozom/clippyts) since #452 but it was not working because `clippyts` will do a [dynamic import to choose which agent it will display](https://github.com/lizozom/clippyts/blob/master/src/agents/index.ts#L3-L11) and the build steps weren't prepared for such convenience.

Now, powered by Vite, we're prepared!