### PR TITLE
fix: list item background color on hover

### DIFF
--- a/packages/core/components/List/List.css.ts
+++ b/packages/core/components/List/List.css.ts
@@ -15,7 +15,7 @@ export const listItem = style({
   color: contract.colors.materialText,
   selectors: {
     '&:hover': {
-      backgroundColor: contract.colors.headerBackground,
+      background: contract.colors.headerBackground,
       color: contract.colors.materialTextInvert,
     },
     '&:not(:has(svg))': {


### PR DESCRIPTION
I noticed this bug when talking to @janneilkka. And here is the fix 🚀 

| Before | After |
| ------- | ----- |
| ![image](https://github.com/user-attachments/assets/85d67666-452e-4014-bbe5-54620edd68b9) | ![image](https://github.com/user-attachments/assets/6ba80725-1d6f-4d80-923e-c14ebd8118f3) |
