### PR TITLE
Feat: extending `className` on missing components

### DIFF
--- a/packages/core/components/Avatar/Avatar.tsx
+++ b/packages/core/components/Avatar/Avatar.tsx
@@ -9,6 +9,7 @@ import type {
 
 import { avatar, imgStyle } from './Avatar.css';
 import { Frame, FrameProps } from '../Frame/Frame';
+import cn from 'classnames';
 
 export type AvatarProps<TAs extends ElementType> = Omit<
   ImgHTMLAttributes<HTMLDivElement>,
@@ -20,10 +21,24 @@ export type AvatarProps<TAs extends ElementType> = Omit<
 
 export const Avatar = forwardRef<HTMLDivElement, AvatarProps<'div'>>(
   (
-    { src, srcSet, alt, circle, children, size = '48px', ...otherProps },
+    {
+      src,
+      srcSet,
+      alt,
+      circle,
+      children,
+      size = '48px',
+      className,
+      ...otherProps
+    },
     ref,
   ) => (
-    <Frame className={avatar({ circle })} ref={ref} {...otherProps} size={size}>
+    <Frame
+      {...otherProps}
+      ref={ref}
+      size={size}
+      className={cn(avatar({ circle }), className)}
+    >
       {src || srcSet ? (
         <img className={imgStyle} src={src} srcSet={srcSet} alt={alt} />
       ) : (

--- a/packages/core/components/Checkbox/Checkbox.tsx
+++ b/packages/core/components/Checkbox/Checkbox.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react';
 import type { CSSProperties, HTMLProps } from 'react';
 
 import * as styles from './Checkbox.css';
+import cn from 'classnames';
 
 export type LabelProps = {
   disabled?: boolean;
@@ -14,8 +15,8 @@ export type CheckboxProps = {
   HTMLProps<HTMLInputElement>;
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ children, style, label, disabled = false, ...rest }, ref) => (
-    <label style={style} className={styles.label}>
+  ({ children, style, label, disabled = false, className, ...rest }, ref) => (
+    <label style={style} className={cn(styles.label, className)}>
       <input
         className={styles.field}
         type="checkbox"

--- a/packages/core/components/Fieldset/Fieldset.tsx
+++ b/packages/core/components/Fieldset/Fieldset.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react';
 import type { HTMLProps } from 'react';
 import * as styles from './Fieldset.css';
 import { Frame, FrameProps } from '../Frame/Frame';
+import cn from 'classnames';
 
 export type FieldSetProps = {
   legend?: string;
@@ -9,8 +10,13 @@ export type FieldSetProps = {
   Omit<FrameProps<'fieldset'>, 'as'>;
 
 export const Fieldset = forwardRef<HTMLFieldSetElement, FieldSetProps>(
-  ({ legend, children, ...rest }, ref) => (
-    <Frame {...rest} as="fieldset" ref={ref} className={styles.field}>
+  ({ legend, children, className, ...rest }, ref) => (
+    <Frame
+      {...rest}
+      as="fieldset"
+      ref={ref}
+      className={cn(styles.field, className)}
+    >
       {legend && <legend className={styles.legend}>{legend}</legend>}
       {children}
     </Frame>

--- a/packages/core/components/Input/Input.tsx
+++ b/packages/core/components/Input/Input.tsx
@@ -1,9 +1,10 @@
 import React, { forwardRef } from 'react';
 import { Frame, FrameProps } from '../Frame/Frame';
 import { input } from './Input.css';
+import cn from 'classnames';
 
 export type InputProps = Omit<FrameProps<'input'>, 'as'>;
 
 export const Input = forwardRef<HTMLInputElement, InputProps>((rest, ref) => (
-  <Frame {...rest} ref={ref} className={input} as="input" />
+  <Frame {...rest} ref={ref} className={cn(input, rest.className)} as="input" />
 ));

--- a/packages/core/components/RadioButton/RadioButton.tsx
+++ b/packages/core/components/RadioButton/RadioButton.tsx
@@ -1,12 +1,13 @@
 import React, { forwardRef } from 'react';
 import type { InputHTMLAttributes } from 'react';
 import { field, icon, label, text } from './RadioButton.css';
+import cn from 'classnames';
 
 export type RadioButtonProps = InputHTMLAttributes<HTMLInputElement>;
 
 export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>(
   ({ children, disabled, ...props }, ref) => (
-    <label className={label}>
+    <label className={cn(label, props.className)}>
       <input
         type="radio"
         disabled={disabled}

--- a/packages/core/components/Tabs/Tab.tsx
+++ b/packages/core/components/Tabs/Tab.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from 'react';
 import type { MouseEvent, HTMLProps } from 'react';
+import cn from 'classnames';
 
 import { tab } from './Tabs.css';
 import { Frame, FrameProps } from '../Frame/Frame';
@@ -16,7 +17,7 @@ export const Tab = forwardRef<HTMLLIElement, TabProps>(
   ({ activeTab, title, ...rest }, ref) => (
     <Frame
       {...rest}
-      className={tab({ active: activeTab === title })}
+      className={cn(tab({ active: activeTab === title }), rest.className)}
       ref={ref}
       as="li"
     >

--- a/packages/core/components/TaskBar/TaskBar.tsx
+++ b/packages/core/components/TaskBar/TaskBar.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 
-import { Frame } from '../Frame/Frame';
+import { Frame, FrameProps } from '../Frame/Frame';
 import { List } from '../List/List';
 
 import { Clock } from './Clock';
@@ -12,10 +12,10 @@ import { ModalEvents, modals, ModalWindow } from '../shared/events';
 
 export type TaskBarProps = {
   list?: ReactElement<typeof List>;
-};
+} & FrameProps<'div'>;
 
 export const TaskBar = forwardRef<HTMLDivElement, TaskBarProps>(
-  ({ list }, ref) => {
+  ({ list, className }, ref) => {
     const [showList, toggleShowList] = useState(false);
     const [activeStart, toggleActiveStart] = useState(false);
     const [modalWindows, setModalWindows] = React.useState<ModalWindow[]>([]);
@@ -73,6 +73,7 @@ export const TaskBar = forwardRef<HTMLDivElement, TaskBarProps>(
         backgroundColor="$material"
         boxShadow="$out"
         ref={ref}
+        className={className}
       >
         {showList && (
           <Frame

--- a/packages/core/components/TextArea/TextArea.tsx
+++ b/packages/core/components/TextArea/TextArea.tsx
@@ -6,11 +6,13 @@ import { input as textarea } from '../Input/Input.css';
 
 export type TextAreaProps = Omit<FrameProps<'textarea'>, 'as'>;
 
-export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((rest, ref) => (
-  <Frame
-    {...rest}
-    ref={ref}
-    className={cn(textarea, rest.className)}
-    as="textarea"
-  />
-));
+export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  (rest, ref) => (
+    <Frame
+      {...rest}
+      ref={ref}
+      className={cn(textarea, rest.className)}
+      as="textarea"
+    />
+  ),
+);

--- a/packages/core/components/TextArea/TextArea.tsx
+++ b/packages/core/components/TextArea/TextArea.tsx
@@ -1,12 +1,16 @@
 import React, { forwardRef } from 'react';
+import cn from 'classnames';
 
 import { Frame, FrameProps } from '../Frame/Frame';
 import { input as textarea } from '../Input/Input.css';
 
 export type TextAreaProps = Omit<FrameProps<'textarea'>, 'as'>;
 
-export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  (rest, ref) => (
-    <Frame {...rest} ref={ref} className={textarea} as="textarea" />
-  ),
-);
+export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((rest, ref) => (
+  <Frame
+    {...rest}
+    ref={ref}
+    className={cn(textarea, rest.className)}
+    as="textarea"
+  />
+));

--- a/packages/core/components/Tree/Node.tsx
+++ b/packages/core/components/Tree/Node.tsx
@@ -86,7 +86,7 @@ export const Node: FC<NodeProps> = ({
   };
 
   return (
-    <Frame as="li" {...rest} className={styles.node}>
+    <Frame as="li" {...rest} className={cn(styles.node, rest.className)}>
       <div className={styles.nodeContent}>
         {hasChildren && (
           <div

--- a/packages/core/components/Tree/Tree.tsx
+++ b/packages/core/components/Tree/Tree.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from 'react';
 import type { ForwardRefExoticComponent, RefAttributes } from 'react';
+import cn from 'classnames';
 
 import { Node, icons, NodeProps, NodeRoot } from './Node';
 import { tree } from './Tree.css';
@@ -8,7 +9,7 @@ import { Frame, FrameProps } from '../Frame/Frame';
 export type TreeProps = {
   data: Array<NodeProps>;
   root?: Omit<NodeProps, 'children'>;
-};
+} & FrameProps<'ul'>;
 
 type TreeComposition = ForwardRefExoticComponent<
   TreeProps & RefAttributes<HTMLUListElement>
@@ -17,11 +18,11 @@ type TreeComposition = ForwardRefExoticComponent<
 } & Omit<FrameProps<'ul'>, 'as'>;
 
 export const Tree = forwardRef<HTMLUListElement, TreeProps>(
-  ({ data, root, ...rest }, ref) => {
+  ({ data = [], root, ...rest }, ref) => {
     return (
       <>
         {root && <NodeRoot {...root} />}
-        <Frame {...rest} className={tree} as="ul" ref={ref}>
+        <Frame {...rest} className={cn(tree, rest.className)} as="ul" ref={ref}>
           {data.map(dataNode => (
             <Node key={dataNode.id} {...dataNode} />
           ))}
@@ -30,9 +31,5 @@ export const Tree = forwardRef<HTMLUListElement, TreeProps>(
     );
   },
 ) as TreeComposition;
-
-Tree.defaultProps = {
-  data: [],
-};
 
 Tree.icons = icons;


### PR DESCRIPTION
This pull request introduces a consistent approach to handling `className` props across multiple components in the `packages/core/components` directory by integrating the `classnames` library. This change simplifies the merging of class names and enhances flexibility for component styling.

### Integration of `classnames` for `className` Prop Handling:

* **Avatar Component**: Added `className` support by merging it with existing styles using `classnames` in the `Avatar` component. (`packages/core/components/Avatar/Avatar.tsx`) [[1]](diffhunk://#diff-4baf7847d1d7edc923cfd97a441e930ad28c022c410777f5309462df550eee33R12) [[2]](diffhunk://#diff-4baf7847d1d7edc923cfd97a441e930ad28c022c410777f5309462df550eee33L23-R41)
* **Checkbox Component**: Incorporated `classnames` to merge `className` with default styles in the `Checkbox` component. (`packages/core/components/Checkbox/Checkbox.tsx`) [[1]](diffhunk://#diff-d4a237af3437480d568879dede938064193a37cf69432f50cd4b074eb74d24f5R5) [[2]](diffhunk://#diff-d4a237af3437480d568879dede938064193a37cf69432f50cd4b074eb74d24f5L17-R19)
* **Fieldset Component**: Updated the `Fieldset` component to use `classnames` for combining `className` with internal styles. (`packages/core/components/Fieldset/Fieldset.tsx`)
* **Input, TextArea, and RadioButton Components**: Refactored these components to use `classnames` for handling `className` merging. (`packages/core/components/Input/Input.tsx`, `packages/core/components/TextArea/TextArea.tsx`, `packages/core/components/RadioButton/RadioButton.tsx`) [[1]](diffhunk://#diff-f88d22c5db165760971d7d90a6a693401955cb454aa234a6687dd13f41b8641fR4-R9) [[2]](diffhunk://#diff-adc2e9d801d4af7419b71feed6ab1ae5b1373991ca1eed47a1efc9a7bef2a5f1R2-R16) [[3]](diffhunk://#diff-128d39ed04088fdb2513550509006331842444ece976bf36112360da89938725R4-R10)
* **Tabs and TaskBar Components**: Adopted `classnames` to streamline `className` merging in these components. (`packages/core/components/Tabs/Tab.tsx`, `packages/core/components/TaskBar/TaskBar.tsx`) [[1]](diffhunk://#diff-caeea9c0065cf71e208d9f77372604f1f3d0d672cb53839ae94360c06a446940R3) [[2]](diffhunk://#diff-caeea9c0065cf71e208d9f77372604f1f3d0d672cb53839ae94360c06a446940L19-R20) [[3]](diffhunk://#diff-f38fb06fcebeafafd856856282d4aebb41be9fdc958f5f8cac6c57310d304992L4-R4) [[4]](diffhunk://#diff-f38fb06fcebeafafd856856282d4aebb41be9fdc958f5f8cac6c57310d304992L15-R18) [[5]](diffhunk://#diff-f38fb06fcebeafafd856856282d4aebb41be9fdc958f5f8cac6c57310d304992R76)

### Tree Component Enhancements:

* **Tree and Node Components**: Updated the `Tree` and `Node` components to use `classnames` for handling `className` props. Removed the `defaultProps` definition for `Tree` as it is redundant with default parameter values. (`packages/core/components/Tree/Tree.tsx`, `packages/core/components/Tree/Node.tsx`) [[1]](diffhunk://#diff-e3b9d90e379dbb6cc0746dca9cea1a49dd0edc6b74fd5604f97cbd8466bfec99R3) [[2]](diffhunk://#diff-e3b9d90e379dbb6cc0746dca9cea1a49dd0edc6b74fd5604f97cbd8466bfec99L11-R12) [[3]](diffhunk://#diff-e3b9d90e379dbb6cc0746dca9cea1a49dd0edc6b74fd5604f97cbd8466bfec99L20-R25) [[4]](diffhunk://#diff-e3b9d90e379dbb6cc0746dca9cea1a49dd0edc6b74fd5604f97cbd8466bfec99L34-L37) [[5]](diffhunk://#diff-acec53231f908c5d63d487aa24b9d88a3a338a602ff74b889f3b75e1f49a3dc5L89-R89)

These changes improve code consistency, enhance flexibility for styling, and simplify the process of extending or overriding styles in these components.