### PR TITLE
Exporting React95 theme contract

### DIFF
--- a/packages/core/components/index.ts
+++ b/packages/core/components/index.ts
@@ -20,6 +20,7 @@ import { Tree } from './Tree/Tree';
 import { Tooltip } from './Tooltip/Tooltip';
 import { TitleBar } from './TitleBar/TitleBar';
 import { Video } from './Video/Video';
+import { contract } from './themes/contract.css';
 
 export {
   Alert,
@@ -44,4 +45,5 @@ export {
   Tooltip,
   TitleBar,
   Video,
+  contract,
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,11 @@
       "import": "./esm/themes/*.css.ts.vanilla.css",
       "require": "./cjs/themes/*.css.ts.vanilla.css"
     },
+    "./contract": {
+      "types": "./types/themes/contract.d.ts",
+      "import": "./esm/themes/contract.css.mjs",
+      "require": "./cjs/themes/contract.css.cjs"
+    },
     "./GlobalStyle": {
       "import": "./esm/GlobalStyle/GlobalStyle.css.ts.vanilla.css",
       "require": "./cjs/GlobalStyle/GlobalStyle.css.ts.vanilla.css"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,11 @@
       "import": "./esm/Alert/Alert.mjs",
       "require": "./cjs/Alert/Alert.cjs"
     },
+    "./Avatar": {
+      "types": "./types/Avatar/Avatar.d.ts",
+      "import": "./esm/Avatar/Avatar.mjs",
+      "require": "./cjs/Avatar/Avatar.cjs"
+    },
     "./Button": {
       "types": "./types/Button/Button.d.ts",
       "import": "./esm/Button/Button.mjs",

--- a/packages/core/stories/contract.stories.tsx
+++ b/packages/core/stories/contract.stories.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react';
+import { contract, Frame, Tree } from '../components';
+import { TreeProps } from '../components/Tree/Tree';
+import copy from 'copy-to-clipboard';
+import {
+  CalcSc,
+  Copy,
+  FilePen,
+  Files,
+  Mspaint,
+  Wangimg129,
+} from '@react95/icons';
+import type { StoryObj } from '@storybook/react';
+
+export default {
+  title: 'Contract',
+};
+
+const treeNodes: TreeProps['data'] = [
+  {
+    id: 0,
+    label: 'space',
+    icon: <CalcSc variant="16x16_4" />,
+    children: Object.entries(contract.space).map(([key, value], id) => ({
+      id,
+      label: `${key}: ${value}`,
+      icon: <Copy variant="16x16_4" />,
+      onClick: () => {
+        copy(value);
+      },
+    })),
+  },
+  {
+    id: 1,
+    label: 'colors',
+    icon: <Mspaint variant="16x16_4" />,
+    children: Object.entries(contract.colors).map(([key, value], id) => ({
+      id,
+      label: `${key}: ${value}`,
+      icon: <Copy variant="16x16_4" />,
+      onClick: () => {
+        copy(value);
+      },
+    })),
+  },
+  {
+    id: 2,
+    label: 'zIndices',
+    icon: <Files variant="16x16_4" />,
+    children: Object.entries(contract.zIndices).map(([key, value], id) => ({
+      id,
+      label: `${key}: ${value}`,
+      icon: <Copy variant="16x16_4" />,
+      onClick: () => {
+        copy(value);
+      },
+    })),
+  },
+  {
+    id: 3,
+    label: 'shadows',
+    icon: <Wangimg129 variant="16x16_4" />,
+    children: Object.entries(contract.shadows).map(([key, value], id) => ({
+      id,
+      label: `${key}: ${value}`,
+      icon: <Tree.icons.FILE_TEXT variant="16x16_4" />,
+      onClick: () => {
+        copy(value);
+      },
+    })),
+  },
+];
+
+type Story = StoryObj<unknown>;
+
+export const Simple: Story = {
+  render: () => {
+    return (
+      <Frame
+        width="470px"
+        p="$10"
+        bgColor="$material"
+        boxShadow="$out"
+        display="flex"
+        flexDirection="column"
+        gap="$8"
+      >
+        <Frame as="p" fontWeight="bold" mt="$0">
+          Contract Theme
+        </Frame>
+        <Frame
+          as="code"
+          bgColor="white"
+          p="$6"
+          alignSelf="start"
+          boxShadow="$in"
+        >
+          import {'{'} contract {'}'} from '@react95/core';
+        </Frame>
+        <Frame>
+          <Tree
+            data={treeNodes}
+            root={{
+              id: -1,
+              label: 'contract',
+              icon: <FilePen variant="16x16_4" />,
+              onClick: () => {
+                copy("import { contract } from '@react95/core';");
+              },
+            }}
+          />
+        </Frame>
+      </Frame>
+    );
+  },
+  parameters: {
+    design: { disable: true },
+  },
+};


### PR DESCRIPTION
This pull request introduces a new `contract` theme to the `@react95/core` package, updates the package's exports to include it, and adds a Storybook story to showcase its usage. The most important changes are grouped below by theme.

### Screenshot

![image](https://github.com/user-attachments/assets/b563e6ac-0038-47c8-8dce-25fe2d2419e4)


### Theme Integration:

* Added `contract` theme to the component exports in `packages/core/components/index.ts` for easier access. [[1]](diffhunk://#diff-6db06e65d01c217a772364ee21d9970d8790a62868049caa8af0ff850145e81cR23) [[2]](diffhunk://#diff-6db06e65d01c217a772364ee21d9970d8790a62868049caa8af0ff850145e81cR48)
* Updated `packages/core/package.json` to include the `contract` theme's type definitions and module paths in the package exports.

### Storybook Additions:

* Created a new Storybook story in `packages/core/stories/contract.stories.tsx` to demonstrate the `contract` theme, including its properties like `space`, `colors`, `zIndices`, and `shadows`. The story uses a `Tree` component to display the theme values interactively and allows users to copy values to the clipboard.

### Additional Export:

* Added `Avatar` component to the package exports in `packages/core/package.json` for better modularity.