### PR TITLE
fix: correct types path for `contract` in `package.json`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
       "require": "./cjs/themes/*.css.ts.vanilla.css"
     },
     "./contract": {
-      "types": "./types/themes/contract.d.ts",
+      "types": "./types/themes/contract.css.d.ts",
       "import": "./esm/themes/contract.css.mjs",
       "require": "./cjs/themes/contract.css.cjs"
     },


### PR DESCRIPTION
Updated the types path for the contract entry in package.json from "./types/themes/contract.d.ts" to "./types/themes/contract.css.d.ts" to ensure proper type definitions are referenced.