### PR TITLE
fix: update TitleBar type to extend `as` prop

### DIFF
--- a/packages/core/components/Modal/Modal.tsx
+++ b/packages/core/components/Modal/Modal.tsx
@@ -61,7 +61,7 @@ export type ModalProps = {
     | ReactElement<TitleBarOptions>[];
 } & Omit<FrameProps<'div'>, 'as'> &
   HTMLAttributes<HTMLDivElement> &
-  Pick<TitleBarBackgroundProps, 'title' | 'icon'>;
+  Pick<TitleBarBackgroundProps<'div'>, 'title' | 'icon'>;
 
 const ModalContent = fixedForwardRef<HTMLDivElement, FrameProps<'div'>>(
   (rest, ref) => (
@@ -248,14 +248,15 @@ const ModalRenderer = (
   );
 };
 
+type ModalComponent = typeof ModalRenderer & {
+  Content: typeof ModalContent;
+  Minimize: typeof ModalMinimize;
+};
+
 export const Modal = Object.assign(
   fixedForwardRef<HTMLDivElement, ModalProps>(ModalRenderer),
   {
     Content: ModalContent,
     Minimize: ModalMinimize,
   },
-) as ModalProps &
-  typeof ModalRenderer & {
-    Content: typeof ModalContent;
-    Minimize: typeof ModalMinimize;
-  };
+) as ModalComponent;

--- a/packages/core/components/TitleBar/TitleBar.tsx
+++ b/packages/core/components/TitleBar/TitleBar.tsx
@@ -4,7 +4,6 @@ import type {
   ElementRef,
   ElementType,
   ForwardedRef,
-  ForwardRefRenderFunction,
   HTMLAttributes,
   ReactElement,
   Ref,
@@ -124,13 +123,18 @@ const Restore = fixedForwardRef<HTMLButtonElement, OptionProps<'button'>>(
   },
 ) as OptionReturnType;
 
-export interface TitleBarBackgroundProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'color'>,
-    FrameProps<'div'> {
-  active?: boolean;
-  icon?: ReactElement;
-  title?: string;
-}
+export type TitleBarBackgroundProps<TAs extends ElementType> = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'color'
+> &
+  FrameProps<TAs> & {
+    active?: boolean;
+    icon?: ReactElement;
+    title?: string;
+  };
+
+export type TitleBarProps<TAs extends ElementType = 'div'> =
+  TitleBarBackgroundProps<TAs>;
 
 interface TitleBarOptions {
   Option: typeof Option;
@@ -142,17 +146,15 @@ interface TitleBarOptions {
   Restore: typeof Restore;
 }
 
-export interface TitleBarProps
-  extends TitleBarBackgroundProps,
-    TitleBarOptions,
-    FrameProps<'div'> {}
-
-const TitleBarRenderer: ForwardRefRenderFunction<
-  HTMLDivElement,
-  TitleBarBackgroundProps
-> = (
-  { children, title = 'UNKNOWN.EXE', icon, active = true, ...rest },
-  ref: Ref<HTMLDivElement>,
+const TitleBarRenderer = <TAs extends ElementType = 'div'>(
+  {
+    children,
+    title = 'UNKNOWN.EXE',
+    icon,
+    active = true,
+    ...rest
+  }: TitleBarBackgroundProps<TAs>,
+  ref: Ref<ElementRef<TAs>>,
 ) => (
   <Frame
     {...rest}
@@ -166,15 +168,18 @@ const TitleBarRenderer: ForwardRefRenderFunction<
   </Frame>
 );
 
-export const TitleBar = Object.assign(
-  fixedForwardRef<HTMLDivElement, TitleBarBackgroundProps>(TitleBarRenderer),
-  {
-    Option,
-    OptionsBox,
-    Help,
-    Close,
-    Maximize,
-    Minimize,
-    Restore,
-  },
-) as TitleBarProps & typeof TitleBarRenderer;
+type TitleBarComponent = <TAs extends ElementType = 'div'>(
+  props: TitleBarProps<TAs> & { ref?: ForwardedRef<ElementRef<TAs>> },
+) => ReactElement;
+
+type TitleBarWithStatics = TitleBarComponent & TitleBarOptions;
+
+export const TitleBar = Object.assign(fixedForwardRef(TitleBarRenderer), {
+  Option,
+  OptionsBox,
+  Help,
+  Close,
+  Maximize,
+  Minimize,
+  Restore,
+}) as TitleBarWithStatics;

--- a/packages/core/stories/titlebar.stories.tsx
+++ b/packages/core/stories/titlebar.stories.tsx
@@ -2,13 +2,13 @@ import { Doc, Star } from '@react95/icons';
 import type { Meta } from '@storybook/react';
 import * as React from 'react';
 
-import { TitleBar, TitleBarProps } from '../components/TitleBar/TitleBar';
+import { TitleBar } from '../components/TitleBar/TitleBar';
 
 export default {
   title: 'TitleBar',
   component: TitleBar,
   tags: ['autodocs'],
-} as Meta<TitleBarProps>;
+} as Meta;
 
 export const Simple = {
   render: () => <TitleBar width="200px" />,


### PR DESCRIPTION
This pull request refactors the `TitleBar` component in `TitleBar.tsx` to improve its type safety and flexibility, especially around polymorphic `as` props and TypeScript generics. The most important changes include updating type definitions for props, refactoring the renderer to support polymorphic elements, and cleaning up legacy type usage.

### TypeScript and Polymorphic Component Improvements

* Refactored `TitleBarBackgroundProps` and `TitleBarProps` to be generic over `ElementType`, enabling the `TitleBar` component to be used with different HTML elements via the `as` prop.
* Updated the `TitleBarRenderer` function to use generic types and `ElementRef<TAs>`, improving type safety for refs and props.
* Removed legacy interface definitions and the use of `ForwardRefRenderFunction` in favor of more flexible generic types. [[1]](diffhunk://#diff-45d9d2f7ce56eb1b3624f6c0ea5272d68aa29057167fcfbd737be047f6c7d751L7) [[2]](diffhunk://#diff-45d9d2f7ce56eb1b3624f6c0ea5272d68aa29057167fcfbd737be047f6c7d751L145-R157)

### Component Export and Static Members

* Changed the export of `TitleBar` to use a generic component type and merged static members (`Option`, `OptionsBox`, etc.) for improved usability and type inference.

These changes make the `TitleBar` component more robust, easier to use with different elements, and better aligned with modern TypeScript patterns.