### PR TITLE
Update TS config

### DIFF
--- a/packages/clippy/src/ClippyProvider.tsx
+++ b/packages/clippy/src/ClippyProvider.tsx
@@ -1,13 +1,16 @@
-import { FC, ReactNode, useEffect, useRef, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 import { initAgent } from 'clippyjs';
 import * as agentLoaders from 'clippyjs/agents';
 import AGENTS, { AgentType } from './agents';
 import { ClippyAgent, ClippyContext } from './ClippyContext';
 
-export const ClippyProvider: FC<{
+export const ClippyProvider = ({
+  children,
+  agentName = AGENTS.CLIPPY,
+}: {
   agentName?: AgentType;
   children?: ReactNode;
-}> = ({ children, agentName = AGENTS.CLIPPY }) => {
+}) => {
   const [clippy, setClippy] = useState<ClippyAgent>();
   const agentRef = useRef<ClippyAgent | null>(null);
 

--- a/packages/clippy/src/ClippyProvider.tsx
+++ b/packages/clippy/src/ClippyProvider.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useEffect, useRef, useState } from 'react';
+import { FC, ReactNode, useEffect, useRef, useState } from 'react';
 import { initAgent } from 'clippyjs';
 import * as agentLoaders from 'clippyjs/agents';
 import AGENTS, { AgentType } from './agents';

--- a/packages/clippy/tests/ClippyProvider.test.tsx
+++ b/packages/clippy/tests/ClippyProvider.test.tsx
@@ -1,6 +1,5 @@
 import { ClippyProvider } from '@react95/clippy';
 import { render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { describe, expect, it } from 'vitest';
 
 describe('ClippyProvider', () => {

--- a/packages/clippy/tests/useClippy.test.tsx
+++ b/packages/clippy/tests/useClippy.test.tsx
@@ -1,15 +1,15 @@
 import { AGENTS, ClippyProvider, useClippy } from '@react95/clippy';
 import { renderHook, waitFor } from '@testing-library/react';
 import { initAgent } from 'clippyjs';
-import type { FC, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { describe, expect, it } from 'vitest';
 import * as agentLoaders from 'clippyjs/agents';
 
 describe('useClippy', () => {
   it('should get agent from ClippyContext', async () => {
-    const wrapper: FC<{
-      children?: ReactNode;
-    }> = ({ children }) => <ClippyProvider>{children}</ClippyProvider>;
+    const wrapper = ({ children }: { children?: ReactNode }) => (
+      <ClippyProvider>{children}</ClippyProvider>
+    );
 
     const agent = renderHook(() => useClippy(), { wrapper });
 
@@ -25,9 +25,9 @@ describe('useClippy', () => {
   });
 
   it('agent should be Clippy by default', async () => {
-    const wrapper: FC<{
-      children?: ReactNode;
-    }> = ({ children }) => <ClippyProvider>{children}</ClippyProvider>;
+    const wrapper = ({ children }: { children?: ReactNode }) => (
+      <ClippyProvider>{children}</ClippyProvider>
+    );
 
     renderHook(() => useClippy(), { wrapper });
 
@@ -39,9 +39,7 @@ describe('useClippy', () => {
   it('agent should be different', async () => {
     const agentName = AGENTS.MERLIN;
 
-    const wrapper: FC<{
-      children?: ReactNode;
-    }> = ({ children }) => (
+    const wrapper = ({ children }: { children?: ReactNode }) => (
       <ClippyProvider agentName={agentName}>{children}</ClippyProvider>
     );
 

--- a/packages/clippy/tests/useClippy.test.tsx
+++ b/packages/clippy/tests/useClippy.test.tsx
@@ -1,14 +1,14 @@
 import { AGENTS, ClippyProvider, useClippy } from '@react95/clippy';
 import { renderHook, waitFor } from '@testing-library/react';
 import { initAgent } from 'clippyjs';
-import React from 'react';
+import type { FC, ReactNode } from 'react';
 import { describe, expect, it } from 'vitest';
 import * as agentLoaders from 'clippyjs/agents';
 
 describe('useClippy', () => {
   it('should get agent from ClippyContext', async () => {
-    const wrapper: React.FC<{
-      children?: React.ReactNode;
+    const wrapper: FC<{
+      children?: ReactNode;
     }> = ({ children }) => <ClippyProvider>{children}</ClippyProvider>;
 
     const agent = renderHook(() => useClippy(), { wrapper });
@@ -25,8 +25,8 @@ describe('useClippy', () => {
   });
 
   it('agent should be Clippy by default', async () => {
-    const wrapper: React.FC<{
-      children?: React.ReactNode;
+    const wrapper: FC<{
+      children?: ReactNode;
     }> = ({ children }) => <ClippyProvider>{children}</ClippyProvider>;
 
     renderHook(() => useClippy(), { wrapper });
@@ -39,8 +39,8 @@ describe('useClippy', () => {
   it('agent should be different', async () => {
     const agentName = AGENTS.MERLIN;
 
-    const wrapper: React.FC<{
-      children?: React.ReactNode;
+    const wrapper: FC<{
+      children?: ReactNode;
     }> = ({ children }) => (
       <ClippyProvider agentName={agentName}>{children}</ClippyProvider>
     );

--- a/packages/clippy/tsconfig.json
+++ b/packages/clippy/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react"
+    "jsx": "react-jsx"
   }
 }

--- a/packages/core/components/Alert/Alert.test.tsx
+++ b/packages/core/components/Alert/Alert.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render } from '../shared/test/utils';
 import { Alert } from './Alert';

--- a/packages/core/components/Alert/Alert.tsx
+++ b/packages/core/components/Alert/Alert.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import { forwardRef, useEffect } from 'react';
 import type { FC } from 'react';
 import { User2, User3, User4, User5 } from '@react95/icons';
 import * as styles from './Alert.css';

--- a/packages/core/components/Alert/Alert.tsx
+++ b/packages/core/components/Alert/Alert.tsx
@@ -1,5 +1,4 @@
 import { forwardRef, useEffect } from 'react';
-import type { FC } from 'react';
 import { User2, User3, User4, User5 } from '@react95/icons';
 import * as styles from './Alert.css';
 
@@ -9,7 +8,7 @@ import sound from './assets/chord.mp3';
 
 export type AlertType = 'error' | 'info' | 'question' | 'warning';
 
-const RenderImage: FC<{ option: string }> = ({ option }) => {
+const RenderImage = ({ option }: { option: string }) => {
   switch (option) {
     case 'info':
       return <User5 width={32} height={32} variant="32x32_4" />;

--- a/packages/core/components/Avatar/Avatar.test.tsx
+++ b/packages/core/components/Avatar/Avatar.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '../shared/test/utils';
 import { Avatar } from './Avatar';

--- a/packages/core/components/Avatar/Avatar.tsx
+++ b/packages/core/components/Avatar/Avatar.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type {
   ElementType,
   ReactElement,

--- a/packages/core/components/Button/Button.test.tsx
+++ b/packages/core/components/Button/Button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render } from '../shared/test/utils';
 import { Button } from './Button';

--- a/packages/core/components/Button/Button.tsx
+++ b/packages/core/components/Button/Button.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type {
   ButtonHTMLAttributes,
   ElementType,

--- a/packages/core/components/Checkbox/Checkbox.test.tsx
+++ b/packages/core/components/Checkbox/Checkbox.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render } from '../shared/test/utils';
 import { Checkbox } from './Checkbox';

--- a/packages/core/components/Checkbox/Checkbox.tsx
+++ b/packages/core/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { CSSProperties, HTMLProps } from 'react';
 
 import * as styles from './Checkbox.css';

--- a/packages/core/components/Dropdown/Dropdown.test.tsx
+++ b/packages/core/components/Dropdown/Dropdown.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { render } from '../shared/test/utils';
 import { Dropdown } from './Dropdown';

--- a/packages/core/components/Dropdown/Dropdown.tsx
+++ b/packages/core/components/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { HTMLProps } from 'react';
 import cn from 'classnames';
 

--- a/packages/core/components/Fieldset/Fieldset.test.tsx
+++ b/packages/core/components/Fieldset/Fieldset.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { render } from '../shared/test/utils';
 import { Fieldset } from './Fieldset';

--- a/packages/core/components/Fieldset/Fieldset.tsx
+++ b/packages/core/components/Fieldset/Fieldset.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { HTMLProps } from 'react';
 import * as styles from './Fieldset.css';
 import { Frame, FrameProps } from '../Frame/Frame';

--- a/packages/core/components/Input/Input.test.tsx
+++ b/packages/core/components/Input/Input.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { render } from '../shared/test/utils';
 import { Input } from './Input';

--- a/packages/core/components/Input/Input.tsx
+++ b/packages/core/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 import { Frame, FrameProps } from '../Frame/Frame';
 import { input } from './Input.css';
 import cn from 'classnames';

--- a/packages/core/components/List/List.test.tsx
+++ b/packages/core/components/List/List.test.tsx
@@ -1,5 +1,4 @@
 import { FolderExe2, MicrosoftExchange, WindowsExplorer } from '@react95/icons';
-import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { waitRender } from '../shared/test/utils';
 import { List } from './List';

--- a/packages/core/components/List/List.tsx
+++ b/packages/core/components/List/List.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type {
   ElementType,
   ForwardedRef,

--- a/packages/core/components/List/ListDivider.tsx
+++ b/packages/core/components/List/ListDivider.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type {
   ElementType,
   ForwardedRef,

--- a/packages/core/components/List/ListItem.tsx
+++ b/packages/core/components/List/ListItem.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type {
   ElementType,
   ForwardedRef,

--- a/packages/core/components/Modal/Modal.test.tsx
+++ b/packages/core/components/Modal/Modal.test.tsx
@@ -1,5 +1,4 @@
 import { Bat } from '@react95/icons';
-import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { List } from '../List/List';
 import { fireEvent, waitRender } from '../shared/test/utils';

--- a/packages/core/components/ProgressBar/ProgressBar.test.tsx
+++ b/packages/core/components/ProgressBar/ProgressBar.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { render } from '../shared/test/utils';
 import { ProgressBar } from './ProgressBar';

--- a/packages/core/components/ProgressBar/ProgressBar.tsx
+++ b/packages/core/components/ProgressBar/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { ElementType, ReactElement, ForwardedRef } from 'react';
 import cn from 'classnames';
 

--- a/packages/core/components/RadioButton/RadioButton.test.tsx
+++ b/packages/core/components/RadioButton/RadioButton.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render } from '../shared/test/utils';
 import { RadioButton } from './RadioButton';

--- a/packages/core/components/RadioButton/RadioButton.tsx
+++ b/packages/core/components/RadioButton/RadioButton.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { InputHTMLAttributes } from 'react';
 import { field, icon, label, text } from './RadioButton.css';
 import cn from 'classnames';

--- a/packages/core/components/Range/Range.test.tsx
+++ b/packages/core/components/Range/Range.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { render } from '../shared/test/utils';
 import { Range } from './Range';

--- a/packages/core/components/Range/Range.tsx
+++ b/packages/core/components/Range/Range.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 import { Frame, FrameProps } from '../Frame/Frame';
 import { range } from './Range.css';
 import cn from 'classnames';

--- a/packages/core/components/Tabs/Tab.tsx
+++ b/packages/core/components/Tabs/Tab.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { MouseEvent, HTMLAttributes } from 'react';
 import cn from 'classnames';
 

--- a/packages/core/components/Tabs/Tabs.test.tsx
+++ b/packages/core/components/Tabs/Tabs.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { fireEvent, render } from '../shared/test/utils';
 import { Tab } from './Tab';

--- a/packages/core/components/Tabs/Tabs.tsx
+++ b/packages/core/components/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState, forwardRef, Children } from 'react';
+import { useState, forwardRef, Children } from 'react';
 import type { MouseEvent, ReactElement, HTMLAttributes } from 'react';
 import cn from 'classnames';
 

--- a/packages/core/components/TaskBar/Clock.tsx
+++ b/packages/core/components/TaskBar/Clock.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Frame } from '../Frame/Frame';
 import { Tooltip } from '../Tooltip/Tooltip';

--- a/packages/core/components/TaskBar/TaskBar.test.tsx
+++ b/packages/core/components/TaskBar/TaskBar.test.tsx
@@ -1,5 +1,4 @@
 import { Bat, ReaderClosed, WindowsExplorer } from '@react95/icons';
-import React from 'react';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { act, fireEvent, render, waitRender } from '../shared/test/utils';

--- a/packages/core/components/TaskBar/WindowButton.tsx
+++ b/packages/core/components/TaskBar/WindowButton.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { ButtonHTMLAttributes } from 'react';
 
 import { ModalWindow } from '../shared/events';

--- a/packages/core/components/TextArea/TextArea.test.tsx
+++ b/packages/core/components/TextArea/TextArea.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { render } from '../shared/test/utils';
 import { TextArea } from './TextArea';

--- a/packages/core/components/TextArea/TextArea.tsx
+++ b/packages/core/components/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, TextareaHTMLAttributes } from 'react';
+import { forwardRef, TextareaHTMLAttributes } from 'react';
 import cn from 'classnames';
 
 import { Frame, FrameProps } from '../Frame/Frame';

--- a/packages/core/components/TitleBar/TitleBar.test.tsx
+++ b/packages/core/components/TitleBar/TitleBar.test.tsx
@@ -1,5 +1,4 @@
 import { Bat } from '@react95/icons';
-import React from 'react';
 import { describe, expect, it } from 'vitest';
 
 import { waitRender } from '../shared/test/utils';

--- a/packages/core/components/TitleBar/TitleBar.tsx
+++ b/packages/core/components/TitleBar/TitleBar.tsx
@@ -6,7 +6,6 @@ import type {
   HTMLAttributes,
   ReactElement,
 } from 'react';
-import React from 'react';
 
 import close from './close.svg';
 import help from './help.svg';

--- a/packages/core/components/Tooltip/Tooltip.test.tsx
+++ b/packages/core/components/Tooltip/Tooltip.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render } from '../shared/test/utils';
 import { Tooltip } from './Tooltip';

--- a/packages/core/components/Tooltip/Tooltip.tsx
+++ b/packages/core/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { useState, forwardRef } from 'react';
+import { useState, forwardRef } from 'react';
 import type { HTMLAttributes, Ref } from 'react';
 import cn from 'classnames';
 

--- a/packages/core/components/Tree/Node.tsx
+++ b/packages/core/components/Tree/Node.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type {
   FC,
   ReactElement,

--- a/packages/core/components/Tree/Node.tsx
+++ b/packages/core/components/Tree/Node.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import type {
-  FC,
   ReactElement,
   MouseEvent,
   KeyboardEvent,
@@ -34,9 +33,12 @@ export const icons = {
   FILE_EXECUTABLE: BatExec,
 } as const;
 
-const NodeIcon: FC<{ hasChildren: boolean; isOpen: boolean }> = ({
+const NodeIcon = ({
   hasChildren,
   isOpen,
+}: {
+  hasChildren: boolean;
+  isOpen: boolean;
 }) => {
   if (!hasChildren) {
     return <Bat variant="16x16_4" data-testid="react95-default-icon-bat" />;
@@ -71,14 +73,14 @@ export type NodeRootProps = NodeBaseProps & {
 
 const EMPTY_CHILDREN: Array<NodeProps> = [];
 
-export const Node: FC<NodeProps> = ({
+export const Node = ({
   children = EMPTY_CHILDREN,
   id,
   icon,
   label,
   onClick = () => {},
   ...rest
-}) => {
+}: NodeProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const hasChildren = children.length > 0;
 
@@ -134,13 +136,13 @@ export const Node: FC<NodeProps> = ({
   );
 };
 
-export const NodeRoot: FC<NodeRootProps> = ({
+export const NodeRoot = ({
   id,
   icon,
   label,
   onClick = () => {},
   ...rest
-}) => {
+}: NodeRootProps) => {
   const onClickHandler = (event: MouseEvent | KeyboardEvent) => {
     onClick(event, {
       id,

--- a/packages/core/components/Tree/Tree.test.tsx
+++ b/packages/core/components/Tree/Tree.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, waitRender } from '../shared/test/utils';
 import { Tree } from './Tree';

--- a/packages/core/components/Tree/Tree.tsx
+++ b/packages/core/components/Tree/Tree.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type {
   ForwardRefExoticComponent,
   HTMLAttributes,

--- a/packages/core/components/Video/Video.css.ts
+++ b/packages/core/components/Video/Video.css.ts
@@ -44,13 +44,26 @@ export const videoFont = style({
   textTransform: 'uppercase',
 });
 
+export const duration = style({
+  marginTop: 'auto',
+});
+
 export const currentTime = style({
   marginTop: 'auto',
   fontSize: 22,
 });
 
+export const openingText = style({
+  height: 12,
+});
+
 export const elapsedTime = style({
   height: contract.space[12],
+});
+
+export const loadingIcon = style({
+  borderRight: 'none',
+  borderBottom: 'none',
 });
 
 export const divider = style({
@@ -99,6 +112,8 @@ globalStyle(`${controlBtn}:disabled svg`, {
 });
 
 export const range = style({
+  width: '70%',
+  marginLeft: 20,
   selectors: {
     '&::-webkit-slider-thumb': {
       height: contract.space[18],

--- a/packages/core/components/Video/Video.test.tsx
+++ b/packages/core/components/Video/Video.test.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import React from 'react';
 import {
   afterEach,
   beforeAll,

--- a/packages/core/components/Video/Video.tsx
+++ b/packages/core/components/Video/Video.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useEffect,
   useState,
   useRef,

--- a/packages/core/components/Video/Video.tsx
+++ b/packages/core/components/Video/Video.tsx
@@ -202,10 +202,7 @@ const VideoRenderer = (
             {loadeddata ? (
               <PlayOrPause playing={playing} />
             ) : (
-              <User4
-                className={styles.loadingIcon}
-                variant="32x32_4"
-              />
+              <User4 className={styles.loadingIcon} variant="32x32_4" />
             )}
           </Button>
           <Button

--- a/packages/core/components/Video/Video.tsx
+++ b/packages/core/components/Video/Video.tsx
@@ -169,16 +169,11 @@ const VideoRenderer = (
       <Frame maxWidth="250px" mx="auto" mb="$4">
         <div className={styles.countDownContainer}>
           <Frame display="flex" flexDirection="column" w="40%">
-            <div
-              className={styles.videoFont}
-              style={{
-                marginTop: 'auto',
-              }}
-            >
+            <div className={cn(styles.videoFont, styles.duration)}>
               {player.current && parseCurrentTime(player.current.duration)}
             </div>
 
-            <div className={styles.videoFont} style={{ height: 12 }}>
+            <div className={cn(styles.videoFont, styles.openingText)}>
               {!loadeddata && 'Openning'}
             </div>
           </Frame>
@@ -208,7 +203,7 @@ const VideoRenderer = (
               <PlayOrPause playing={playing} />
             ) : (
               <User4
-                style={{ borderRight: 'none', borderBottom: 'none' }}
+                className={styles.loadingIcon}
                 variant="32x32_4"
               />
             )}
@@ -246,10 +241,6 @@ const VideoRenderer = (
             max="100"
             step="1"
             value={progress}
-            style={{
-              width: '70%',
-              marginLeft: 20,
-            }}
             onChange={({ target }) => {
               const { current: video } = player;
 

--- a/packages/core/components/Video/Video.tsx
+++ b/packages/core/components/Video/Video.tsx
@@ -5,7 +5,7 @@ import {
   forwardRef,
   useImperativeHandle,
 } from 'react';
-import type { FC, Ref, HTMLProps } from 'react';
+import type { Ref, HTMLProps } from 'react';
 import { Mplayer113, User4 } from '@react95/icons';
 
 import * as styles from './Video.css';
@@ -19,7 +19,7 @@ import cn from 'classnames';
 
 type SourceProps = Pick<HTMLSourceElement, 'src'>;
 
-const Source: FC<SourceProps> = ({ src }) => (
+const Source = ({ src }: SourceProps) => (
   <source src={src} type={`video/${src.substring(src.length - 3)}`} />
 );
 

--- a/packages/core/components/Video/__snapshots__/Video.snap
+++ b/packages/core/components/Video/__snapshots__/Video.snap
@@ -38,12 +38,10 @@ exports[`<Video /> > Snapshot > should match snapshot 1`] = `
           style="--width-mobile__iuzg895c: 40%; --display-mobile__iuzg890: flex; --flexDirection-mobile__iuzg893c: column;"
         >
           <div
-            class="Video_videoFont__13gnpv05"
-            style="margin-top: auto;"
+            class="Video_videoFont__13gnpv05 Video_duration__13gnpv06"
           />
           <div
-            class="Video_videoFont__13gnpv05"
-            style="height: 12px;"
+            class="Video_videoFont__13gnpv05 Video_openingText__13gnpv08"
           >
             Openning
           </div>
@@ -53,10 +51,10 @@ exports[`<Video /> > Snapshot > should match snapshot 1`] = `
           style="--width-mobile__iuzg895c: 40%; --display-mobile__iuzg890: flex; --flexDirection-mobile__iuzg893c: column;"
         >
           <div
-            class="Video_videoFont__13gnpv05 Video_currentTime__13gnpv06"
+            class="Video_videoFont__13gnpv05 Video_currentTime__13gnpv07"
           />
           <div
-            class="Video_videoFont__13gnpv05 Video_elapsedTime__13gnpv07"
+            class="Video_videoFont__13gnpv05 Video_elapsedTime__13gnpv09"
           >
             time
           </div>
@@ -66,16 +64,16 @@ exports[`<Video /> > Snapshot > should match snapshot 1`] = `
         class="Video_controls__13gnpv03"
       >
         <button
-          class="Button_button__1bzq74l0 Video_controlBtn__13gnpv09"
+          class="Button_button__1bzq74l0 Video_controlBtn__13gnpv0c"
           disabled=""
         >
           <svg test-file-stub
-            style="border-right-width: initial; border-right-style: none; border-right-color: none; border-bottom-width: initial; border-bottom-style: none; border-bottom-color: none;"
+            classname="Video_loadingIcon__13gnpv0a"
             variant="32x32_4"
           />
         </button>
         <button
-          class="Button_button__1bzq74l0 Video_controlBtn__13gnpv09"
+          class="Button_button__1bzq74l0 Video_controlBtn__13gnpv0c"
           disabled=""
         >
           <svg
@@ -90,7 +88,7 @@ exports[`<Video /> > Snapshot > should match snapshot 1`] = `
           </svg>
         </button>
         <button
-          class="Button_button__1bzq74l0 Video_controlBtn__13gnpv09"
+          class="Button_button__1bzq74l0 Video_controlBtn__13gnpv0c"
           disabled=""
         >
           <svg
@@ -107,11 +105,10 @@ exports[`<Video /> > Snapshot > should match snapshot 1`] = `
           </svg>
         </button>
         <input
-          class="Range_range__1i4w9z20 Video_range__13gnpv0a"
+          class="Range_range__1i4w9z20 Video_range__13gnpv0d"
           max="100"
           min="0"
           step="1"
-          style="width: 70%; margin-left: 20px;"
           type="range"
           value="0"
         />

--- a/packages/core/components/Video/buttons/Fullscreen.tsx
+++ b/packages/core/components/Video/buttons/Fullscreen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { HTMLAttributes } from 'react';
 
 const Fullscreen = (props: HTMLAttributes<SVGElement>) => (

--- a/packages/core/components/Video/buttons/Pause.tsx
+++ b/packages/core/components/Video/buttons/Pause.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { HTMLAttributes } from 'react';
 
 const Pause = (props: HTMLAttributes<SVGElement>) => (

--- a/packages/core/components/Video/buttons/Play.tsx
+++ b/packages/core/components/Video/buttons/Play.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { HTMLAttributes } from 'react';
 
 const Play = (props: HTMLAttributes<SVGElement>) => (

--- a/packages/core/components/Video/buttons/Stop.tsx
+++ b/packages/core/components/Video/buttons/Stop.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { HTMLAttributes } from 'react';
 
 const Stop = (props: HTMLAttributes<SVGElement>) => (

--- a/packages/core/components/shared/modal-integration.test.tsx
+++ b/packages/core/components/shared/modal-integration.test.tsx
@@ -10,9 +10,7 @@ import { Computer } from '@react95/icons';
 // Test component that uses useModal hook
 const TestModalController = () => {
   const { remove, minimize, restore, focus, subscribe } = useModal();
-  const [events, setEvents] = useState<
-    Array<{ id: number; text: string }>
-  >([]);
+  const [events, setEvents] = useState<Array<{ id: number; text: string }>>([]);
   const eventCounter = useRef(0);
 
   useEffect(() => {

--- a/packages/core/components/shared/modal-integration.test.tsx
+++ b/packages/core/components/shared/modal-integration.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, waitFor, fireEvent } from '@testing-library/react';
 import { Modal } from '../Modal/Modal';
@@ -10,12 +10,12 @@ import { Computer } from '@react95/icons';
 // Test component that uses useModal hook
 const TestModalController = () => {
   const { remove, minimize, restore, focus, subscribe } = useModal();
-  const [events, setEvents] = React.useState<
+  const [events, setEvents] = useState<
     Array<{ id: number; text: string }>
   >([]);
-  const eventCounter = React.useRef(0);
+  const eventCounter = useRef(0);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const addEvent = (text: string) => {
       const id = ++eventCounter.current;
       setEvents(prev => [...prev, { id, text }]);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -209,7 +209,6 @@
   "scripts": {
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build -o docs",
-    "postbuild-storybook": "cp -r ../../node_modules/clippyts/dist/agents ./docs/assets",
     "build": "yarn build:vite && yarn build:types",
     "build:vite": "vite build",
     "build:types": "yarn build:types:core && yarn build:types:themes && yarn build:types:global",

--- a/packages/core/stories/avatar.stories.tsx
+++ b/packages/core/stories/avatar.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import * as React from 'react';
 
 import { Avatar, AvatarProps } from '../components/Avatar/Avatar';
 import { Frame } from '../components';

--- a/packages/core/stories/button.stories.tsx
+++ b/packages/core/stories/button.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta } from '@storybook/react';
-import * as React from 'react';
 
 import { Button, ButtonProps } from '../components/Button/Button';
 

--- a/packages/core/stories/contract.stories.tsx
+++ b/packages/core/stories/contract.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   Button,
   contract,

--- a/packages/core/stories/cursor.stories.tsx
+++ b/packages/core/stories/cursor.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta } from '@storybook/react';
-import * as React from 'react';
 
 import { Frame } from '../components';
 import { Cursor } from '../components/Cursor/Cursor.css';

--- a/packages/core/stories/dropdown.stories.tsx
+++ b/packages/core/stories/dropdown.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta } from '@storybook/react';
-import * as React from 'react';
 
 import { Dropdown, DropdownProps } from '../components/Dropdown/Dropdown';
 

--- a/packages/core/stories/fieldset.stories.tsx
+++ b/packages/core/stories/fieldset.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta } from '@storybook/react';
-import * as React from 'react';
 
 import { Fieldset, FieldSetProps } from '../components/Fieldset/Fieldset';
 import { Frame, Checkbox } from '../components';

--- a/packages/core/stories/input.stories.tsx
+++ b/packages/core/stories/input.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta } from '@storybook/react';
-import * as React from 'react';
 
 import { Input, InputProps } from '../components/Input/Input';
 

--- a/packages/core/stories/list.stories.tsx
+++ b/packages/core/stories/list.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta } from '@storybook/react';
-import * as React from 'react';
 
 import {
   Computer3,

--- a/packages/core/stories/progressbar.stories.tsx
+++ b/packages/core/stories/progressbar.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import * as React from 'react';
 
 import {
   ProgressBar,

--- a/packages/core/stories/range.stories.tsx
+++ b/packages/core/stories/range.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta } from '@storybook/react';
-import * as React from 'react';
 
 import { Range, RangeProps } from '../components/Range/Range';
 

--- a/packages/core/stories/tabs.stories.tsx
+++ b/packages/core/stories/tabs.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta } from '@storybook/react';
-import * as React from 'react';
 
 import { Checkbox, Dropdown, Fieldset, Input } from '../components';
 import { Tab } from '../components/Tabs/Tab';

--- a/packages/core/stories/titlebar.stories.tsx
+++ b/packages/core/stories/titlebar.stories.tsx
@@ -1,6 +1,5 @@
 import { Doc, Star } from '@react95/icons';
 import type { Meta } from '@storybook/react';
-import * as React from 'react';
 
 import { TitleBar } from '../components/TitleBar/TitleBar';
 

--- a/packages/core/stories/tooltip.stories.tsx
+++ b/packages/core/stories/tooltip.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import * as React from 'react';
 
 import { Tooltip, TooltipProps } from '../components/Tooltip/Tooltip';
 

--- a/packages/core/stories/tree.stories.tsx
+++ b/packages/core/stories/tree.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta } from '@storybook/react';
-import * as React from 'react';
 
 import { Tree, TreeProps } from '../components/Tree/Tree';
 import { Explorer100 } from '@react95/icons';

--- a/packages/core/stories/video.stories.tsx
+++ b/packages/core/stories/video.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta } from '@storybook/react';
-import * as React from 'react';
 
 import { Video } from '../components/Video/Video';
 import EXPLORER_VIDEO from './EXPLORER.mp4';

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "types": ["@testing-library/jest-dom"]
   },
   "include": ["components", "stories", "types", "../../types"],

--- a/packages/core/tsconfig.production.json
+++ b/packages/core/tsconfig.production.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/types",
-    "jsx": "react",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
     "declaration": true,
     "emitDeclarationOnly": true
   },

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "allowJs": true,
     "outDir": "dist/types",
-    "jsx": "react",
+    "jsx": "react-jsx",
+    "noUnusedLocals": false,
     "incremental": true,
     "declaration": true,
     "emitDeclarationOnly": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,18 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "ES2020",
+    "module": "ESNext",
+    "target": "ES2022",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "sourceMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "strictPropertyInitialization": false,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
     "noUnusedLocals": true,
     "declaration": true,
-    "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-    "incremental": false,
-    "skipDefaultLibCheck": true,
+    "isolatedModules": true,
     "skipLibCheck": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES2022",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "sourceMap": true,
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "strictPropertyInitialization": false,


### PR DESCRIPTION
This pull request primarily removes unnecessary imports of the React default export (`import React from 'react'`) and the `FC` type from component and test files, following modern React and TypeScript best practices. It also updates type annotations for function components and adjusts the JSX runtime configuration to use the automatic JSX transform. These changes help streamline the codebase and reduce boilerplate.

**React import and type cleanup:**

* Removed unused `import React from 'react'` and `import type { FC } from 'react'` from multiple component and test files, such as `Alert.tsx`, `Avatar.tsx`, `Button.tsx`, `Checkbox.tsx`, `Dropdown.tsx`, `Fieldset.tsx`, `Input.tsx`, and `List.tsx`, as well as corresponding test files. [[1]](diffhunk://#diff-13266dfb76ddb9fda46db8bf59267be2c0634953fef896ea7ffed84736b49b0aL1-R1) [[2]](diffhunk://#diff-4baf7847d1d7edc923cfd97a441e930ad28c022c410777f5309462df550eee33L1-R1) [[3]](diffhunk://#diff-8775347ca631f372b740a0af83555955c8a65e17cb629456836566524e038d39L1) [[4]](diffhunk://#diff-d4a237af3437480d568879dede938064193a37cf69432f50cd4b074eb74d24f5L1-R1) [[5]](diffhunk://#diff-17f2e52a02432b2cbd65363df8bedc827a3c3772e631a38528a7ac6a72297c61L1-R1) [[6]](diffhunk://#diff-792c66e2abec9be6bed9ffc855663ebe49e4bb638f0d5537a3b417404877ddadL1-R1) [[7]](diffhunk://#diff-f88d22c5db165760971d7d90a6a693401955cb454aa234a6687dd13f41b8641fL1-R1) [[8]](diffhunk://#diff-02b900e94f0b4fdbcb21f480618cd2a6c38be10e84a5a766b43b3296b2ca6642L1) [[9]](diffhunk://#diff-b450720b76112343fe78ad5d7ba686804ad1c6191a6224f197128807b4183505L1) [[10]](diffhunk://#diff-9a66448b7b2b864d1f553c6c33ffc1509eb360252da2a0bb07c3826b84dcc1e9L1) [[11]](diffhunk://#diff-72b1a76370746e428b5e2657de2d78e1d56c54ecd3d98ea0d8f97b878504cfe4L1) [[12]](diffhunk://#diff-55ecc98a1db157d6c9001b8a1a6533cd724385fde692e439fa5247172a8b49d1L1) [[13]](diffhunk://#diff-a432342783d5f48e17c3c2b03e4ae5f528bb984d9d5adae735aba636fb431461L1) [[14]](diffhunk://#diff-819f70713360408cf9536edfd7d42fc462c11cf9fd9b9f1cbe811d26503c5a9eL1) [[15]](diffhunk://#diff-d15c7955bce4646431a26848b085431f8b503491669e84865bbfd6ca6cb6320dL1) [[16]](diffhunk://#diff-c422e6e0c189bcd6b483713ba2075bb3515aa5e70d4492ad5362d5ba4e43a6e8L2)

* Replaced usages of the `FC` type with explicit function component type annotations, e.g., for `RenderImage` and `ClippyProvider`. [[1]](diffhunk://#diff-13266dfb76ddb9fda46db8bf59267be2c0634953fef896ea7ffed84736b49b0aL12-R11) [[2]](diffhunk://#diff-ba3842e21292ad5688ee3c56f19ca2b46721e148dabdc870a43e1309ca600acfL1-R13) [[3]](diffhunk://#diff-4a5b441c0b7ed803fd07455eeac485439c33b74f3a7882c131bbf9bb29f629cbL4-R12) [[4]](diffhunk://#diff-4a5b441c0b7ed803fd07455eeac485439c33b74f3a7882c131bbf9bb29f629cbL28-R30) [[5]](diffhunk://#diff-4a5b441c0b7ed803fd07455eeac485439c33b74f3a7882c131bbf9bb29f629cbL42-R42)

**JSX runtime update:**

* Changed the `jsx` compiler option in `tsconfig.json` from `"react"` to `"react-jsx"` to enable the automatic JSX runtime, which no longer requires explicit React imports in JSX files.

These updates modernize the codebase, making it cleaner and more maintainable.