### PR TITLE
Simplify alpha release command by removing unnecessary --yes flag

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -15,7 +15,7 @@ then
   # use the `alpha` dist-tag to avoid overwriting `latest` on npm, we split the
   # process: first run versioning + changelog with --skip-publish, then publish
   # explicitly with --tag=alpha.
-  yarn nx release --preid=alpha --yes --skip-publish
+  yarn nx release --preid=alpha --skip-publish
   yarn nx release publish --tag=alpha
 else
   echo "Nothing to publish on branch $BRANCH..."


### PR DESCRIPTION
The --yes flag is not needed for the alpha release process, as it is already handled by the script logic. This change simplifies the command for clarity and consistency.