### PR TITLE
fix: publish @react95/core, icons and clippy from their built dist directory

### DIFF
--- a/.github/workflows/nx.yml
+++ b/.github/workflows/nx.yml
@@ -13,11 +13,11 @@ jobs:
       number-of-agents: 3
       main-branch-name: master
       init-commands: |
-        yarn nx-cloud start-ci-run --stop-agents-after="lint,test,build,prepublishOnly"
+        yarn nx-cloud start-ci-run --stop-agents-after="lint,test,build"
       parallel-commands: |
         yarn nx-cloud record -- yarn nx format:check
       parallel-commands-on-agents: |
-        yarn nx affected -t lint,test,build,prepublishOnly --parallel=3
+        yarn nx affected -t lint,test,build --parallel=3
 
   agents:
     name: Nx Cloud - Agents

--- a/nx.json
+++ b/nx.json
@@ -24,9 +24,6 @@
       "dependsOn": ["^lint"],
       "cache": true
     },
-    "prepublishOnly": {
-      "dependsOn": ["build"]
-    },
     "nx-release-publish": {
       "dependsOn": ["build"],
       "options": {

--- a/nx.json
+++ b/nx.json
@@ -28,6 +28,7 @@
       "dependsOn": ["build"]
     },
     "nx-release-publish": {
+      "dependsOn": ["build"],
       "options": {
         "registry": "https://registry.npmjs.org/"
       }

--- a/packages/clippy/package.json
+++ b/packages/clippy/package.json
@@ -17,6 +17,15 @@
     "directory": "dist",
     "provenance": true
   },
+  "nx": {
+    "targets": {
+      "nx-release-publish": {
+        "options": {
+          "packageRoot": "{projectRoot}/dist"
+        }
+      }
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/React95/React95.git",
@@ -28,9 +37,8 @@
     "build": "yarn build:vite && yarn build:types",
     "build:vite": "vite build",
     "build:types": "yarn tsc -b ./tsconfig.types.json",
+    "postbuild": "node ../../scripts/prepublish.js --types",
     "lint": "eslint --ext ts,tsx --quiet src tests",
-    "prepublish": "yarn build",
-    "prepublishOnly": "node ../../scripts/prepublish.js --types",
     "test": "vitest run --config=../../config/test/clippy.js"
   },
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -216,17 +216,25 @@
     "build:types:themes": "yarn tsc -p ./tsconfig.themes.json",
     "build:types:global": "yarn tsc -p ./tsconfig.global.json",
     "lint": "eslint --ext ts,tsx --quiet components",
+    "postbuild": "node ../../scripts/prepublish.js --types",
     "postbuild:cjs": "copyfiles ./components/**/*.{svg,png,eot,ttf,woff,woff2,mp3} ./dist/cjs -u 1",
     "postbuild:esm": "copyfiles ./components/**/*.{svg,png,eot,ttf,woff,woff2,mp3} ./dist/esm -u 1",
     "prebuild": "rimraf ./dist",
-    "prepublish": "yarn build",
-    "prepublishOnly": "node ../../scripts/prepublish.js --types",
     "test": "vitest run --config=../../config/test/core.js"
   },
   "publishConfig": {
     "access": "public",
     "directory": "dist",
     "provenance": true
+  },
+  "nx": {
+    "targets": {
+      "nx-release-publish": {
+        "options": {
+          "packageRoot": "{projectRoot}/dist"
+        }
+      }
+    }
   },
   "sideEffects": [
     "**/*.{woff2,woff,ttf,eot}"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -60,10 +60,17 @@
     "build:cjs": "cross-env NODE_ENV=cjs yarn babel ./src --out-dir dist/cjs --extensions .ts,.tsx",
     "build:css": "cp ./icons.css ./dist/icons.css && ts-node-script scripts/fixCss.ts",
     "build:svg": "cp -r src/svg ./dist",
-    "postbuild": "cp -r ./png ./dist/png",
-    "prepublish": "yarn build",
-    "prepublishOnly": "node ../../scripts/prepublish.js --types && ts-node-script scripts/addExports.ts",
+    "postbuild": "cp -r ./png ./dist/png && node ../../scripts/prepublish.js --types && ts-node-script scripts/addExports.ts",
     "test": "vitest run --config=../../config/test/icons.js"
+  },
+  "nx": {
+    "targets": {
+      "nx-release-publish": {
+        "options": {
+          "packageRoot": "{projectRoot}/dist"
+        }
+      }
+    }
   },
   "devDependencies": {
     "@svgr/core": "^8.1.0",


### PR DESCRIPTION
## Summary

`@react95/core@9.8.0` and `@react95/icons@2.5.0` are currently broken on npm: `publint` reports dozens of `exports`/`main` paths pointing at files that don't exist in the published tarball (https://publint.dev/@react95/core@9.8.0). `@react95/clippy` has the same underlying bug.

Root cause: all three packages set `publishConfig.directory: "dist"`, a convention only understood natively by `pnpm publish`. This repo's release pipeline runs `nx release publish` with yarn/npm, and Nx's `nx-release-publish` executor ignores `publishConfig.directory`, publishing the source directory as-is instead of `dist/`. Since `main`/`exports` in each package's `package.json` are written relative to `dist` (e.g. `./esm/index.mjs`), the published tarballs referenced non-existent files, and for `core` even shipped the entire source tree (components, stories, storybook config) instead of the built output.

- `nx.json`: `nx-release-publish` now depends on `build`, so a stale/missing `dist/` can't be published.
- `core`, `icons`, `clippy`: set `nx-release-publish`'s `packageRoot` to `{projectRoot}/dist` so Nx actually publishes the built package, and move the `dist/package.json` generation (`scripts/prepublish.js`, plus `scripts/addExports.ts` for icons) from the `prepublishOnly` npm hook — which Nx never triggers — to `postbuild`, which runs on every `yarn build`.