### PR TITLE
fix(release): resync dist package.json version before publish

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -24,8 +24,12 @@
       "dependsOn": ["^lint"],
       "cache": true
     },
-    "nx-release-publish": {
+    "sync-dist-version": {
       "dependsOn": ["build"],
+      "cache": false
+    },
+    "nx-release-publish": {
+      "dependsOn": ["sync-dist-version"],
       "options": {
         "registry": "https://registry.npmjs.org/"
       }

--- a/packages/clippy/package.json
+++ b/packages/clippy/package.json
@@ -38,6 +38,7 @@
     "build:vite": "vite build",
     "build:types": "yarn tsc -b ./tsconfig.types.json",
     "postbuild": "node ../../scripts/prepublish.js --types",
+    "sync-dist-version": "node ../../scripts/prepublish.js --types",
     "lint": "eslint --ext ts,tsx --quiet src tests",
     "test": "vitest run --config=../../config/test/clippy.js"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -220,6 +220,7 @@
     "postbuild:cjs": "copyfiles ./components/**/*.{svg,png,eot,ttf,woff,woff2,mp3} ./dist/cjs -u 1",
     "postbuild:esm": "copyfiles ./components/**/*.{svg,png,eot,ttf,woff,woff2,mp3} ./dist/esm -u 1",
     "prebuild": "rimraf ./dist",
+    "sync-dist-version": "node ../../scripts/prepublish.js --types",
     "test": "vitest run --config=../../config/test/core.js"
   },
   "publishConfig": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -61,6 +61,7 @@
     "build:css": "cp ./icons.css ./dist/icons.css && ts-node-script scripts/fixCss.ts",
     "build:svg": "cp -r src/svg ./dist",
     "postbuild": "cp -r ./png ./dist/png && node ../../scripts/prepublish.js --types && ts-node-script scripts/addExports.ts",
+    "sync-dist-version": "cp -r ./png ./dist/png && node ../../scripts/prepublish.js --types && ts-node-script scripts/addExports.ts",
     "test": "vitest run --config=../../config/test/icons.js"
   },
   "nx": {


### PR DESCRIPTION
## Problem

After merging #537, the next `build_and_publish` run showed `nx-release-publish` succeeding (✔) for `@react95/core`, `@react95/icons`, and `@react95/clippy`, but none of them actually landed a new version on npm.

Root cause: `build_and_publish.yml` runs `yarn build` before `nx release --yes` bumps versions. The `dist/package.json` generated during build captures whatever version is in the source `package.json` at that moment — the *pre-bump* version. `nx-release-publish` reads the version straight from `dist/package.json` (via the `packageRoot` override from #537), compares it against the registry, sees it already matches the latest published version, and skips the publish while still returning success.

## Fix

Add a `sync-dist-version` target (`cache: false`) that reruns the `dist/package.json` generation after the version bump but before publish, so `nx-release-publish` reads the version nx actually resolved instead of a stale one.

## Verification

- `yarn lint:all`, `yarn test`, `yarn build` all pass.
- Simulated the bug: built with the old version, bumped source `package.json`, ran `sync-dist-version`, confirmed `dist/package.json`'s version updates to match without rebuilding.
- Validated the built packages with `publint` (copied `dist/` outside the repo, since it's gitignored and skews `publint`'s file-detection when run in place): 0 errors for all three packages.