### PR TITLE
fix(clippy): declare minimum supported Node.js version

### DIFF
--- a/packages/clippy/package.json
+++ b/packages/clippy/package.json
@@ -12,6 +12,9 @@
   "homepage": "https://react95.github.io/React95",
   "license": "MIT",
   "main": "index.js",
+  "engines": {
+    "node": ">=18"
+  },
   "publishConfig": {
     "access": "public",
     "directory": "dist",


### PR DESCRIPTION
publint (https://publint.dev) flags the published `@react95/clippy` package for missing the `engines.node` field. Declare it explicitly.

Small, isolated change to a single package, intended to also serve as a validation merge for the release pipeline (npm token / OTP issue was reported fixed).