### PR TITLE
fix(release): pin the publish executor for dist-published packages

### DIFF
--- a/packages/clippy/package.json
+++ b/packages/clippy/package.json
@@ -23,6 +23,7 @@
   "nx": {
     "targets": {
       "nx-release-publish": {
+        "executor": "@nx/js:release-publish",
         "options": {
           "packageRoot": "{projectRoot}/dist"
         }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -231,6 +231,7 @@
   "nx": {
     "targets": {
       "nx-release-publish": {
+        "executor": "@nx/js:release-publish",
         "options": {
           "packageRoot": "{projectRoot}/dist"
         }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -67,6 +67,7 @@
   "nx": {
     "targets": {
       "nx-release-publish": {
+        "executor": "@nx/js:release-publish",
         "options": {
           "packageRoot": "{projectRoot}/dist"
         }


### PR DESCRIPTION
## Problem

After #538, `core`, `icons`, and `clippy`'s `nx-release-publish` task consistently reported success (✔, 0s, no output) in CI, but the packages never actually landed on npm (confirmed directly against the registry — versions stayed unchanged).

Root cause: `nx show project @react95/core --json` reveals the actual executor resolved for the `nx-release-publish` target is `nx:noop`, not `@nx/js:release-publish`:

```json
"nx-release-publish": {
  "options": { "packageRoot": "packages/core/dist", "registry": "..." },
  "executor": "nx:noop"
}
```

`cra-template` (no `nx-release-publish` override in its package.json) correctly resolves to `@nx/js:release-publish`. The difference: core/icons/clippy override this target's `options.packageRoot` via the package.json `"nx"` field (added in #537/#538). That partial override replaces the executor inferred by the release plugin with the default `nx:noop`, instead of merging with it — so the task always "succeeds" instantly without ever calling `npm publish`.

## Fix

Explicitly set `"executor": "@nx/js:release-publish"` alongside the `packageRoot` override in each of the three packages' `"nx"` target config.

## Verification

- `nx show project @react95/core|icons|clippy --json` now reports the real executor instead of `nx:noop`.
- `yarn nx run @react95/core:nx-release-publish --dry-run` now prints the full tarball manifest (527 files) instead of completing silently in 0s.
- `yarn nx release --dry-run --yes` (simulating the next release) now shows real publish attempts with full tarball output for core (527 files), clippy (69 files), and icons (7539 files).
- `yarn lint:all`, `yarn test`, `yarn build` all pass.